### PR TITLE
Refactor Storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,15 @@
 - **Evolution Path**: FileStorage (POC) → S3Storage (Production)
 - **User Storage**: Support for user profiles, auth methods, and sessions
 - **Location**: `role_play/common/storage.py`
+- **Per-User Data Segmentation**: All user-specific data organized under user ID prefix
+  - Pattern: `users/{user_id}/profile`, `users/{user_id}/chat_logs/{session_id}`, etc.
+  - Benefits: Easier per-user operations, better access control, cleaner organization
+  - Migration path: FileStorage uses actual directories, cloud storage uses key prefixes
+- **Key/Path Conventions**: 
+  - No file extensions in storage keys (no .json suffix)
+  - Storage implementations handle serialization internally
+  - Keys are opaque strings that work identically across FileStorage/GCS/S3
+  - Example: `users/123/profile` not `users/123.json`
 
 ### 8. **Multi-Environment Support**
 - **Environment Configs**: Separate configs for dev/beta/prod
@@ -57,7 +66,7 @@
 - **Stateless Handlers**: ChatHandler created per-request via FastAPI dependency injection
 - **Singleton Services**: ContentLoader, ChatLogger, and InMemorySessionService shared across requests
 - **File Locking**: ChatLogger implements FileLock for safe concurrent JSONL writes
-- **Storage Format**: `user_id_session_id.jsonl` files with structured events (session_start, message, session_end)
+- **Storage Format**: `users/{user_id}/chat_logs/{session_id}` with structured JSONL events (session_start, message, session_end)
 - **Session State**: ADK session stores metadata (character_id, scenario_id, message_count) + reference to JSONL file
 - **On-Demand Runners**: ADK Agent and Runner created per message, not stored between requests
 - **Export Ready**: ChatLogger provides text export and session listing without touching ADK state
@@ -102,6 +111,13 @@
 - [x] Create `role_play/common/exceptions.py` - Custom exceptions
 - [x] Create `role_play/common/storage.py` - Storage abstraction (FileStorage, S3Storage)
 - [x] Create `role_play/common/auth.py` - AuthManager, TokenData, UserRole, AuthProvider, User model
+- [ ] Update storage implementation for per-user data segmentation and extensible locking
+  - [ ] Refactor FileStorage to use `users/{user_id}/` prefix pattern
+  - [ ] Remove .json file extensions from storage keys
+  - [ ] Add configurable locking strategies (file, object, redis)
+  - [ ] Update ChatLogger to use new storage paths
+  - [ ] Add GCSStorage and S3Storage implementations
+  - [ ] Add monitoring capabilities for lock performance
 
 ### Server Core
 - [x] Create `role_play/server/base_handler.py` - BaseHandler abstract class

--- a/src/python/role_play/common/storage.py
+++ b/src/python/role_play/common/storage.py
@@ -3,23 +3,94 @@
 import json
 import os
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Generator, Union
+from filelock import FileLock, Timeout
 
 from .exceptions import StorageError
 from .models import User, UserAuthMethod, SessionData
 from .time_utils import utc_now
 
 
+class LockAcquisitionError(StorageError):
+    """Raised when a lock cannot be acquired."""
+    pass
+
+
 class StorageBackend(ABC):
     """
-    Abstract base class for storage backends.
+    Abstract base class for storage backends with locking support.
     
-    WARNING: Implementations should be thread-safe for production use.
-    FileStorage is suitable for development/testing but not for high-concurrency
-    environments. Consider S3Storage or database backends for production scaling.
+    All implementations must be thread-safe and support distributed locking
+    for production use. The locking mechanism is configurable per implementation.
+    
+    This uses a string-first approach since most data is JSON/text, with
+    optional bytes methods for binary data when needed.
     """
 
+    @abstractmethod
+    @contextmanager
+    def lock(self, resource_path: str, timeout: float = 5.0) -> Generator[None, None, None]:
+        """
+        Acquire an exclusive lock for a resource.
+        
+        Args:
+            resource_path: The resource path to lock
+            timeout: Maximum time to wait for lock acquisition
+            
+        Yields:
+            None
+            
+        Raises:
+            LockAcquisitionError: If lock cannot be acquired within timeout
+        """
+        pass
+
+    @abstractmethod
+    async def read(self, path: str) -> str:
+        """Read text data from storage."""
+        pass
+
+    @abstractmethod
+    async def write(self, path: str, data: str) -> None:
+        """Write text data to storage."""
+        pass
+
+    @abstractmethod
+    async def append(self, path: str, data: str) -> None:
+        """Append text data to storage."""
+        pass
+
+    @abstractmethod
+    async def exists(self, path: str) -> bool:
+        """Check if a path exists in storage."""
+        pass
+
+    @abstractmethod
+    async def delete(self, path: str) -> bool:
+        """Delete a path from storage."""
+        pass
+
+    @abstractmethod
+    async def list_keys(self, prefix: str) -> List[str]:
+        """List all keys with the given prefix."""
+        pass
+
+    # Optional bytes methods for binary data (can be overridden for efficiency)
+    async def read_bytes(self, path: str) -> bytes:
+        """Read binary data. Default implementation converts from string."""
+        return (await self.read(path)).encode('utf-8')
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        """Write binary data. Default implementation converts to string."""
+        await self.write(path, data.decode('utf-8'))
+
+    async def append_bytes(self, path: str, data: bytes) -> None:
+        """Append binary data. Default implementation converts to string."""
+        await self.append(path, data.decode('utf-8'))
+
+    # High-level user management methods
     @abstractmethod
     async def get_user(self, user_id: str) -> Optional[User]:
         """Get user by ID."""
@@ -115,193 +186,366 @@ class StorageBackend(ABC):
 
 class FileStorage(StorageBackend):
     """
-    File-based storage backend for development and testing.
+    File-based storage backend with file locking support.
     
-    WARNING: This implementation is NOT thread-safe and should only be used
-    for development, testing, or single-user scenarios. For production use
-    with multiple concurrent users, implement proper file locking or use
-    a database/S3 backend instead.
+    Uses filelock for thread-safe operations and implements per-user
+    data segmentation. Suitable for development and single-server deployments.
     """
 
     def __init__(self, storage_dir: str = "data"):
-        self.storage_dir = Path(storage_dir)
+        self.storage_dir = Path(storage_dir).resolve()
         self.storage_dir.mkdir(exist_ok=True)
         
-        self.users_dir = self.storage_dir / "users"
-        self.auth_methods_dir = self.storage_dir / "auth_methods"
-        self.sessions_dir = self.storage_dir / "sessions"
-        self.data_dir = self.storage_dir / "data"
+        # Create lock directory
+        self.locks_dir = self.storage_dir / ".locks"
+        self.locks_dir.mkdir(exist_ok=True)
+
+    def _get_lock_path(self, resource_path: str) -> Path:
+        """Get the lock file path for a resource."""
+        # Replace path separators with underscores for flat lock directory
+        lock_name = resource_path.replace('/', '_') + '.lock'
+        return self.locks_dir / lock_name
+
+    @contextmanager
+    def lock(self, resource_path: str, timeout: float = 5.0) -> Generator[None, None, None]:
+        """
+        Acquire a file-based lock for a resource.
         
-        for dir_path in [self.users_dir, self.auth_methods_dir, self.sessions_dir, self.data_dir]:
-            dir_path.mkdir(exist_ok=True)
-
-    def _read_json_file(self, file_path: Path) -> Optional[Dict[str, Any]]:
-        """Read and parse JSON file."""
+        Args:
+            resource_path: The resource path to lock
+            timeout: Maximum time to wait for lock acquisition
+            
+        Yields:
+            None
+            
+        Raises:
+            LockAcquisitionError: If lock cannot be acquired within timeout
+        """
+        lock_path = self._get_lock_path(resource_path)
+        lock = FileLock(str(lock_path), timeout=timeout)
+        
         try:
-            if file_path.exists():
-                with open(file_path, 'r') as f:
-                    return json.load(f)
-            return None
-        except (json.JSONDecodeError, IOError) as e:
-            raise StorageError(f"Failed to read file {file_path}: {e}")
+            with lock:
+                yield
+        except Timeout:
+            raise LockAcquisitionError(
+                f"Failed to acquire lock for {resource_path} within {timeout} seconds"
+            )
 
-    def _write_json_file(self, file_path: Path, data: Dict[str, Any]) -> None:
-        """Write data to JSON file."""
+    def _get_storage_path(self, key: str) -> Path:
+        """Convert a storage key to an actual file path."""
+        # Ensure key doesn't escape storage directory
+        if '..' in key:
+            raise StorageError(f"Invalid key: {key}")
+        
+        return self.storage_dir / key
+
+    async def read(self, path: str) -> str:
+        """Read text data from a file."""
+        file_path = self._get_storage_path(path)
+        
         try:
-            with open(file_path, 'w') as f:
-                json.dump(data, f, indent=2, default=str)
+            with open(file_path, 'r', encoding='utf-8') as f:
+                return f.read()
+        except FileNotFoundError:
+            raise StorageError(f"Path not found: {path}")
         except IOError as e:
-            raise StorageError(f"Failed to write file {file_path}: {e}")
+            raise StorageError(f"Failed to read {path}: {e}")
 
+    async def write(self, path: str, data: str) -> None:
+        """Write text data to a file."""
+        file_path = self._get_storage_path(path)
+        
+        # Create parent directories if needed
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(data)
+        except IOError as e:
+            raise StorageError(f"Failed to write {path}: {e}")
+
+    async def append(self, path: str, data: str) -> None:
+        """Append text data to a file."""
+        file_path = self._get_storage_path(path)
+        
+        # Create parent directories if needed
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            with open(file_path, 'a', encoding='utf-8') as f:
+                f.write(data)
+        except IOError as e:
+            raise StorageError(f"Failed to append to {path}: {e}")
+
+    # Override bytes methods for better efficiency with actual file operations
+    async def read_bytes(self, path: str) -> bytes:
+        """Read binary data from a file."""
+        file_path = self._get_storage_path(path)
+        
+        try:
+            with open(file_path, 'rb') as f:
+                return f.read()
+        except FileNotFoundError:
+            raise StorageError(f"Path not found: {path}")
+        except IOError as e:
+            raise StorageError(f"Failed to read {path}: {e}")
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        """Write binary data to a file."""
+        file_path = self._get_storage_path(path)
+        
+        # Create parent directories if needed
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            with open(file_path, 'wb') as f:
+                f.write(data)
+        except IOError as e:
+            raise StorageError(f"Failed to write {path}: {e}")
+
+    async def append_bytes(self, path: str, data: bytes) -> None:
+        """Append binary data to a file."""
+        file_path = self._get_storage_path(path)
+        
+        # Create parent directories if needed
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            with open(file_path, 'ab') as f:
+                f.write(data)
+        except IOError as e:
+            raise StorageError(f"Failed to append to {path}: {e}")
+
+    async def exists(self, path: str) -> bool:
+        """Check if a file exists."""
+        file_path = self._get_storage_path(path)
+        return file_path.exists()
+
+    async def delete(self, path: str) -> bool:
+        """Delete a file."""
+        file_path = self._get_storage_path(path)
+        if file_path.exists():
+            file_path.unlink()
+            return True
+        return False
+
+    async def list_keys(self, prefix: str) -> List[str]:
+        """List all keys with the given prefix."""
+        prefix_path = self._get_storage_path(prefix)
+        keys = []
+        
+        if prefix_path.exists():
+            for file_path in prefix_path.rglob('*'):
+                if file_path.is_file() and not file_path.name.startswith('.'):
+                    # Convert back to storage key format
+                    relative_path = file_path.relative_to(self.storage_dir)
+                    keys.append(str(relative_path))
+        
+        return keys
+
+    # Helper methods for JSON data
+    async def _read_json(self, path: str) -> Optional[Dict[str, Any]]:
+        """Read and parse JSON data."""
+        try:
+            data = await self.read(path)
+            return json.loads(data)
+        except StorageError:
+            return None
+        except json.JSONDecodeError as e:
+            raise StorageError(f"Failed to parse JSON from {path}: {e}")
+
+    async def _write_json(self, path: str, data: Dict[str, Any]) -> None:
+        """Write data as JSON."""
+        json_str = json.dumps(data, indent=2, default=str)
+        await self.write(path, json_str)
+
+    # User management implementation
     async def get_user(self, user_id: str) -> Optional[User]:
         """Get user by ID."""
-        user_file = self.users_dir / f"{user_id}.json"
-        user_data = self._read_json_file(user_file)
+        user_path = f"users/{user_id}/profile"
+        user_data = await self._read_json(user_path)
         if user_data:
             return User(**user_data)
         return None
 
     async def get_user_by_username(self, username: str) -> Optional[User]:
         """Get user by username."""
-        for user_file in self.users_dir.glob("*.json"):
-            user_data = self._read_json_file(user_file)
-            if user_data and user_data.get("username") == username:
-                return User(**user_data)
+        # This is inefficient for file storage, but works for development
+        user_keys = await self.list_keys("users/")
+        
+        for key in user_keys:
+            if key.endswith("/profile"):
+                user_data = await self._read_json(key)
+                if user_data and user_data.get("username") == username:
+                    return User(**user_data)
         return None
 
     async def get_user_by_email(self, email: str) -> Optional[User]:
         """Get user by email."""
-        for user_file in self.users_dir.glob("*.json"):
-            user_data = self._read_json_file(user_file)
-            if user_data and user_data.get("email") == email:
-                return User(**user_data)
+        # This is inefficient for file storage, but works for development
+        user_keys = await self.list_keys("users/")
+        
+        for key in user_keys:
+            if key.endswith("/profile"):
+                user_data = await self._read_json(key)
+                if user_data and user_data.get("email") == email:
+                    return User(**user_data)
         return None
 
     async def create_user(self, user: User) -> User:
         """Create a new user."""
-        user_file = self.users_dir / f"{user.id}.json"
-        if user_file.exists():
+        user_path = f"users/{user.id}/profile"
+        
+        if await self.exists(user_path):
             raise StorageError(f"User {user.id} already exists")
         
-        self._write_json_file(user_file, user.model_dump())
+        with self.lock(user_path):
+            await self._write_json(user_path, user.model_dump())
+        
         return user
 
     async def update_user(self, user: User) -> User:
         """Update an existing user."""
-        user_file = self.users_dir / f"{user.id}.json"
-        if not user_file.exists():
+        user_path = f"users/{user.id}/profile"
+        
+        if not await self.exists(user_path):
             raise StorageError(f"User {user.id} not found")
         
         user.updated_at = utc_now()
-        self._write_json_file(user_file, user.model_dump())
+        
+        with self.lock(user_path):
+            await self._write_json(user_path, user.model_dump())
+        
         return user
 
     async def delete_user(self, user_id: str) -> bool:
-        """Delete a user."""
-        user_file = self.users_dir / f"{user_id}.json"
-        if user_file.exists():
-            user_file.unlink()
-            return True
-        return False
+        """Delete a user and all their data."""
+        user_dir = f"users/{user_id}"
+        
+        # Delete all user data
+        user_keys = await self.list_keys(user_dir)
+        for key in user_keys:
+            await self.delete(key)
+        
+        return True
 
     async def get_user_auth_methods(self, user_id: str) -> List[UserAuthMethod]:
         """Get all auth methods for a user."""
         auth_methods = []
-        for auth_file in self.auth_methods_dir.glob("*.json"):
-            auth_data = self._read_json_file(auth_file)
-            if auth_data and auth_data.get("user_id") == user_id:
+        auth_keys = await self.list_keys(f"users/{user_id}/auth_methods/")
+        
+        for key in auth_keys:
+            auth_data = await self._read_json(key)
+            if auth_data:
                 auth_methods.append(UserAuthMethod(**auth_data))
+        
         return auth_methods
 
     async def get_user_auth_method(
         self, provider: str, provider_user_id: str
     ) -> Optional[UserAuthMethod]:
         """Get auth method by provider and provider user ID."""
-        for auth_file in self.auth_methods_dir.glob("*.json"):
-            auth_data = self._read_json_file(auth_file)
-            if (auth_data and 
-                auth_data.get("provider") == provider and 
-                auth_data.get("provider_user_id") == provider_user_id):
-                return UserAuthMethod(**auth_data)
+        # This requires scanning all users - inefficient but works for development
+        user_keys = await self.list_keys("users/")
+        
+        for key in user_keys:
+            if "/auth_methods/" in key:
+                auth_data = await self._read_json(key)
+                if (auth_data and 
+                    auth_data.get("provider") == provider and 
+                    auth_data.get("provider_user_id") == provider_user_id):
+                    return UserAuthMethod(**auth_data)
         return None
 
     async def create_user_auth_method(self, auth_method: UserAuthMethod) -> UserAuthMethod:
         """Create a new auth method for a user."""
-        auth_file = self.auth_methods_dir / f"{auth_method.id}.json"
-        if auth_file.exists():
+        auth_path = f"users/{auth_method.user_id}/auth_methods/{auth_method.id}"
+        
+        if await self.exists(auth_path):
             raise StorageError(f"Auth method {auth_method.id} already exists")
         
-        self._write_json_file(auth_file, auth_method.model_dump())
+        with self.lock(auth_path):
+            await self._write_json(auth_path, auth_method.model_dump())
+        
         return auth_method
 
     async def update_user_auth_method(self, auth_method: UserAuthMethod) -> UserAuthMethod:
         """Update an existing auth method."""
-        auth_file = self.auth_methods_dir / f"{auth_method.id}.json"
-        if not auth_file.exists():
+        auth_path = f"users/{auth_method.user_id}/auth_methods/{auth_method.id}"
+        
+        if not await self.exists(auth_path):
             raise StorageError(f"Auth method {auth_method.id} not found")
         
-        self._write_json_file(auth_file, auth_method.model_dump())
+        with self.lock(auth_path):
+            await self._write_json(auth_path, auth_method.model_dump())
+        
         return auth_method
 
     async def delete_user_auth_method(self, auth_method_id: str) -> bool:
         """Delete an auth method."""
-        auth_file = self.auth_methods_dir / f"{auth_method_id}.json"
-        if auth_file.exists():
-            auth_file.unlink()
-            return True
+        # Need to find the auth method first to get user_id
+        user_keys = await self.list_keys("users/")
+        
+        for key in user_keys:
+            if key.endswith(f"/auth_methods/{auth_method_id}"):
+                return await self.delete(key)
+        
         return False
 
     async def create_session(self, session: SessionData) -> SessionData:
         """Create a new session."""
-        session_file = self.sessions_dir / f"{session.session_id}.json"
-        if session_file.exists():
+        session_path = f"sessions/{session.session_id}"
+        
+        if await self.exists(session_path):
             raise StorageError(f"Session {session.session_id} already exists")
         
-        self._write_json_file(session_file, session.model_dump())
+        with self.lock(session_path):
+            await self._write_json(session_path, session.model_dump())
+        
         return session
 
     async def get_session(self, session_id: str) -> Optional[SessionData]:
         """Get session by ID."""
-        session_file = self.sessions_dir / f"{session_id}.json"
-        session_data = self._read_json_file(session_file)
+        session_path = f"sessions/{session_id}"
+        session_data = await self._read_json(session_path)
         if session_data:
             return SessionData(**session_data)
         return None
 
     async def update_session(self, session: SessionData) -> SessionData:
         """Update an existing session."""
-        session_file = self.sessions_dir / f"{session.session_id}.json"
-        if not session_file.exists():
+        session_path = f"sessions/{session.session_id}"
+        
+        if not await self.exists(session_path):
             raise StorageError(f"Session {session.session_id} not found")
         
-        self._write_json_file(session_file, session.model_dump())
+        with self.lock(session_path):
+            await self._write_json(session_path, session.model_dump())
+        
         return session
 
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""
-        session_file = self.sessions_dir / f"{session_id}.json"
-        if session_file.exists():
-            session_file.unlink()
-            return True
-        return False
+        session_path = f"sessions/{session_id}"
+        return await self.delete(session_path)
 
     async def store_data(self, key: str, data: Any) -> None:
         """Store arbitrary data."""
-        data_file = self.data_dir / f"{key}.json"
-        self._write_json_file(data_file, {"data": data})
+        data_path = f"data/{key}"
+        
+        with self.lock(data_path):
+            await self._write_json(data_path, {"data": data})
 
     async def get_data(self, key: str) -> Optional[Any]:
         """Get arbitrary data."""
-        data_file = self.data_dir / f"{key}.json"
-        file_data = self._read_json_file(data_file)
+        data_path = f"data/{key}"
+        file_data = await self._read_json(data_path)
         if file_data:
             return file_data.get("data")
         return None
 
     async def delete_data(self, key: str) -> bool:
         """Delete arbitrary data."""
-        data_file = self.data_dir / f"{key}.json"
-        if data_file.exists():
-            data_file.unlink()
-            return True
-        return False
+        data_path = f"data/{key}"
+        return await self.delete(data_path)

--- a/src/python/role_play/common/storage.py
+++ b/src/python/role_play/common/storage.py
@@ -45,37 +45,37 @@ class StorageBackend(ABC):
         Raises:
             LockAcquisitionError: If lock cannot be acquired within timeout
         """
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def read(self, path: str) -> str:
         """Read text data from storage."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def write(self, path: str, data: str) -> None:
         """Write text data to storage."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def append(self, path: str, data: str) -> None:
         """Append text data to storage."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def exists(self, path: str) -> bool:
         """Check if a path exists in storage."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def delete(self, path: str) -> bool:
         """Delete a path from storage."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def list_keys(self, prefix: str) -> List[str]:
         """List all keys with the given prefix."""
-        pass
+        pass  # pragma: no cover
 
     # Optional bytes methods for binary data (can be overridden for efficiency)
     async def read_bytes(self, path: str) -> bytes:
@@ -94,94 +94,94 @@ class StorageBackend(ABC):
     @abstractmethod
     async def get_user(self, user_id: str) -> Optional[User]:
         """Get user by ID."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_user_by_username(self, username: str) -> Optional[User]:
         """Get user by username."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_user_by_email(self, email: str) -> Optional[User]:
         """Get user by email."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def create_user(self, user: User) -> User:
         """Create a new user."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def update_user(self, user: User) -> User:
         """Update an existing user."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def delete_user(self, user_id: str) -> bool:
         """Delete a user."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_user_auth_methods(self, user_id: str) -> List[UserAuthMethod]:
         """Get all auth methods for a user."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_user_auth_method(
         self, provider: str, provider_user_id: str
     ) -> Optional[UserAuthMethod]:
         """Get auth method by provider and provider user ID."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def create_user_auth_method(self, auth_method: UserAuthMethod) -> UserAuthMethod:
         """Create a new auth method for a user."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def update_user_auth_method(self, auth_method: UserAuthMethod) -> UserAuthMethod:
         """Update an existing auth method."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def delete_user_auth_method(self, auth_method_id: str) -> bool:
         """Delete an auth method."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def create_session(self, session: SessionData) -> SessionData:
         """Create a new session."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_session(self, session_id: str) -> Optional[SessionData]:
         """Get session by ID."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def update_session(self, session: SessionData) -> SessionData:
         """Update an existing session."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def delete_session(self, session_id: str) -> bool:
         """Delete a session."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def store_data(self, key: str, data: Any) -> None:
         """Store arbitrary data."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def get_data(self, key: str) -> Optional[Any]:
         """Get arbitrary data."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     async def delete_data(self, key: str) -> bool:
         """Delete arbitrary data."""
-        pass
+        pass  # pragma: no cover
 
 
 class FileStorage(StorageBackend):

--- a/src/python/role_play/server/dependencies.py
+++ b/src/python/role_play/server/dependencies.py
@@ -168,16 +168,14 @@ def get_content_loader() -> ContentLoader:
     return ContentLoader()
 
 
-@lru_cache(maxsize=None)
-def get_chat_logger() -> ChatLogger:
+def get_chat_logger(
+    storage: Annotated[StorageBackend, Depends(get_storage_backend)]
+) -> ChatLogger:
     """
-    Provides a singleton instance of ChatLogger.
-    The storage path for chat logs is derived from the main server config.
+    Provides a ChatLogger instance with injected storage backend.
+    Note: This is NOT a singleton as it depends on the storage backend.
     """
-    config = get_server_config()
-    # Store chat logs in a 'chat_logs' subdirectory of the main storage path
-    chat_logs_path = Path(config.storage_path) / "chat_logs"
-    return ChatLogger(storage_path_str=str(chat_logs_path))
+    return ChatLogger(storage_backend=storage)
 
 
 @lru_cache(maxsize=None)

--- a/storage.md
+++ b/storage.md
@@ -1,0 +1,148 @@
+Cloud Storage Backend Design (Pragmatic & Extensible)This document outlines a design for a versatile storage backend supporting local files, Google Cloud Storage (GCS), and AWS S3, with an integrated and extensible distributed locking mechanism. It prioritizes a pragmatic initial implementation with a clear path for future enhancements, guided by monitoring and clear decision criteria.1. Core Concepts & GoalsAbstraction: Maintain a clear Storage interface, with concrete implementations for each backend.Configurability: Allow selection and configuration of storage backends (file, GCS, S3) and locking strategies via a YAML file.Cloud in Dev: Enable development environments to directly use GCS or S3.Centralized & Extensible Locking (Strategy Pattern): Implement locking at the storage abstraction layer using a strategy pattern. Provide a "good enough" initial object-based locking for cloud storage (especially for GCS), with a simplified, pragmatic approach for S3 object locks. Make it easy to switch to a more robust Redis-based strategy later via configuration.Monitorability: Ensure the locking mechanism can be effectively monitored to understand its performance, detect issues, and inform decisions about when to evolve the locking strategy.Clear Guidance: Provide clear criteria and documented guarantees for choosing the appropriate locking strategy based on operational needs.2. Storage Abstract Base Class (ABC) and LockConfigThe Storage ABC and LockConfig provide the foundation for flexibility. The Storage class will internally select or be provided with a specific lock strategy implementation based on its configuration.# In src/python/role_play/common/storage.py (or similar)
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Generator, Any, Optional, Literal, Union
+from pydantic import BaseModel, Field
+import time
+import uuid # For unique owner IDs for lock implementations
+import os # For FileStorage locks
+# from redis import Redis # Conditionally imported by implementations
+# from filelock import FileLock, Timeout # Conditionally imported by FileStorage
+
+class LockAcquisitionError(Exception):
+    """Custom exception for lock acquisition failures."""
+    pass
+
+# --- Configuration for Locking ---
+class LockConfig(BaseModel):
+    strategy: Literal["object", "redis", "file"] = Field(
+        default="object",
+        description="Locking strategy: 'object' for cloud storage object locks, "
+                    "'redis' for Redis-based locks, 'file' for local file locks."
+    )
+    lease_duration_seconds: int = 60
+    retry_attempts: int = 3
+    retry_delay_seconds: float = 1.0
+
+    # Redis-specific settings (used if strategy is 'redis')
+    redis_host: Optional[str] = None
+    redis_port: Optional[int] = None
+    redis_password: Optional[str] = None
+    redis_db: Optional[int] = 0
+
+    # File-lock specific (used by FileStorage)
+    file_lock_dir: Optional[str] = None
+
+# --- Base Storage Config (assumed to be part of your existing config structure) ---
+class BaseStorageConfig(BaseModel): # Example structure
+    type: str
+    lock: LockConfig = Field(default_factory=LockConfig)
+    # Add other common storage config fields if any
+
+class FileStorageConfig(BaseStorageConfig):
+    type: Literal["file"] = "file"
+    base_dir: str
+    lock: LockConfig = Field(default_factory=lambda: LockConfig(strategy="file"))
+
+
+class GCSStorageConfig(BaseStorageConfig):
+    type: Literal["gcs"] = "gcs"
+    bucket: str
+    prefix: str = ""
+    project_id: Optional[str] = None
+    credentials_file: Optional[str] = None
+    lock: LockConfig = Field(default_factory=lambda: LockConfig(strategy="object"))
+
+
+class S3StorageConfig(BaseStorageConfig):
+    type: Literal["s3"] = "s3"
+    bucket: str
+    prefix: str = ""
+    region_name: Optional[str] = None
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    endpoint_url: Optional[str] = None
+    lock: LockConfig = Field(default_factory=lambda: LockConfig(strategy="object"))
+
+StorageConfigUnion = Union[FileStorageConfig, GCSStorageConfig, S3StorageConfig]
+
+
+# --- Storage ABC ---
+# (Conceptual: LockStrategy ABC would be defined for the strategy pattern)
+# class LockStrategy(ABC):
+#     @abstractmethod
+#     @contextmanager
+#     def acquire(self, resource_name: str) -> Generator[None, None, None]:
+#         pass
+
+class Storage(ABC):
+    def __init__(self, config: StorageConfigUnion):
+        self.config = config
+        # self._lock_strategy_instance = self._create_lock_strategy() # Instantiated internally
+
+    # def _create_lock_strategy(self) -> LockStrategy:
+    #     """Factory method for instantiating the correct lock strategy."""
+    #     lock_conf = self.config.lock
+    #     if lock_conf.strategy == "redis":
+    #         return RedisLockStrategy(lock_conf, # other necessary params like logger #)
+    #     elif lock_conf.strategy == "file":
+    #         return FileLockStrategy(lock_conf, # base_dir from self.config #)
+    #     elif lock_conf.strategy == "object":
+    #         if isinstance(self.config, GCSStorageConfig): # or self.config.type == "gcs"
+    #             return GCSObjectLockStrategy(lock_conf, # gcs_client, bucket, prefix #)
+    #         elif isinstance(self.config, S3StorageConfig): # or self.config.type == "s3"
+    #             return S3ObjectLockStrategy(lock_conf, # s3_client, bucket, prefix #)
+    #     raise ValueError(f"Unsupported lock strategy '{lock_conf.strategy}' for storage type '{self.config.type}'")
+
+
+    @abstractmethod
+    def read(self, path: str) -> bytes:
+        pass
+
+    @abstractmethod
+    def write(self, path: str, content: bytes, content_type: Optional[str] = None):
+        pass
+
+    @abstractmethod
+    def exists(self, path: str) -> bool:
+        pass
+
+    # ... other abstract methods: delete, list_files, list_dirs ...
+
+    @abstractmethod
+    @contextmanager
+    def lock(self, resource_name: str) -> Generator[None, None, None]:
+        """
+        Acquires an exclusive lock for a resource. Use as a context manager.
+        Delegates to an internal lock strategy instance based on self.config.lock.
+        Raises LockAcquisitionError if lock cannot be acquired.
+        """
+        # Implementation would use self._lock_strategy_instance.acquire(resource_name)
+        pass
+
+YAML Configuration Example (with Lock Guarantees Documentation):storage:
+  type: s3 # or 'gcs' or 'file'
+  bucket: "your-bucket-name"
+  prefix: "app_data/"
+  # region_name: "us-west-2" # For S3
+
+  lock:
+    strategy: "object" # Options: "object", "redis", "file"
+                       # Guarantees for "object" strategy:
+                       #   GCS: Strong consistency, atomic operations via if_generation_match.
+                       #   S3: Best-effort, eventual consistency for lock state, GET-after-PUT verification.
+                       # Guarantees for "redis" strategy:
+                       #   Strong consistency (typical Redis setup), atomic operations (SET NX PX). Fastest performance.
+                       # Guarantees for "file" strategy:
+                       #   Robust for single-host, relies on OS-level file locking.
+    lease_duration_seconds: 60 # Critical for "object" and "redis" strategies.
+    retry_attempts: 3
+    retry_delay_seconds: 1.0
+
+    # --- To switch to Redis later for S3/GCS locks ---
+    # strategy: "redis"
+    # lease_duration_seconds: 30
+    # redis_host: "your-redis-host"
+    # redis_port: 6379
+    # redis_db: 0
+3. Concrete Storage ImplementationsThe lock method within each concrete storage class (FileStorage, GCSStorage, S3Storage) will be responsible for instantiating and using the appropriate lock strategy (FileLockStrategy, GCSObjectLockStrategy, S3ObjectLockStrategy, RedisLockStrategy) based on self.config.lock.strategy and the storage type.a. FileStorageLocking (lock.strategy: "file"): Uses a FileLockStrategy which internally uses the filelock library.b. GCSStorageLocking (lock.strategy: "object"): Uses a GCSObjectLockStrategy. Leverages GCS's atomic "create if not exists" capability.Locking (lock.strategy: "redis"): Uses a RedisLockStrategy.c. S3StorageLocking (lock.strategy: "object" - Simplified "Lazy" Approach): Uses an S3ObjectLockStrategy implementing the best-effort mechanism.Documentation: The S3ObjectLockStrategy documentation and associated configuration notes must clearly state its best-effort nature and recommend the redis strategy for high-contention or mission-critical scenarios on S3.Locking (lock.strategy: "redis"): Uses a RedisLockStrategy. This is the preferred robust solution for S3.4. Storage Factory & Impact on ChatLoggerStorage Factory (get_storage_backend): Remains the same.Impact on ChatLogger: Remains the same.5. Monitoring Lock Performance(This section remains largely the same as in the previous version, detailing key metrics, why they are important, and implementation suggestions.)Effective monitoring is crucial to understand the behavior of the distributed locking mechanism, identify bottlenecks or contention, and make an informed decision about when to evolve the locking strategy (e.g., transition from object-based locks to Redis).Key Metrics to Monitor:(Metrics like lock_acquisition_attempts_total, lock_acquisition_success_total, etc., as previously detailed)Why Monitor These Metrics?(Reasons like identifying high failure rates, increasing latency, etc., as previously detailed)Implementation Suggestions for Monitoring:(Suggestions like using prometheus_client, tagging metrics, alerting, dashboards, as previously detailed)6. Locking Strategy Decision Matrix & GuaranteesChoosing the right locking strategy depends on the specific requirements of the environment and workload. Monitoring (Section 5) provides the data to make informed decisions about evolving this strategy.Decision Matrix:ScenarioRecommended Lock StrategyRationaleDev/Test EnvironmentsfileSimple, fast, no external dependencies, robust for single-host.Production (Low RPS/Contention)object (GCS preferred over S3 if available)Cost-effective, leverages cloud storage. GCS offers stronger atomicity.Production (High RPS/Contention)redisBest performance, strong consistency, designed for high throughput.High Contention (Specific Resources)redisRedis handles high contention much more gracefully than object locks.Cost Sensitive (and low contention)objectAvoids cost of a separate Redis service. Accept S3 best-effort.Mission-Critical Lockingredis (with HA setup & thorough monitoring)Highest reliability and performance for critical sections.Documenting Lock Guarantees:It's crucial to understand and document the guarantees provided by each lock strategy. This information should be easily accessible, potentially as comments within the YAML configuration (as shown in the example in Section 2) or in operational runbooks.file Strategy:Guarantees: Robust for single-host scenarios. Relies on OS-level file locking primitives.Limitations: Not suitable for distributed environments (multiple servers/processes accessing shared storage unless that storage has its own distributed lock manager, which this strategy doesn't assume).object Strategy (GCS):Guarantees: Strong consistency for lock state due to GCS's atomic operations (e.g., if_generation_match=0).Limitations: Higher latency than Redis. Performance can degrade under very high contention.object Strategy (S3 - Simplified/Best-Effort):Guarantees: Best-effort. Relies on GET-after-PUT for verification and lease expiry for cleanup. Eventual consistency of S3 can impact lock state visibility under extreme conditions or network partitions, though less likely for single-object operations.Limitations: Not as robust as GCS object locks or Redis, especially under high contention or in complex failure scenarios. Prone to race conditions if lease-based cleanup is the primary mechanism for handling failed lock holders.redis Strategy:Guarantees: Strong consistency (with a typical Redis setup). Atomic operations (e.g., SET resource_key owner_id NX PX lease_ms). Designed for high performance and high contention.Limitations: Introduces an additional system dependency (Redis). Requires proper Redis deployment (standalone, Sentinel for HA, or Cluster).7. Deployment ConsiderationsActively monitor lock performance metrics, especially if using the object strategy for S3 in production. Be prepared to switch to the redis strategy if monitoring indicates issues.When using the redis strategy, ensure Redis is deployed robustly (e.g., with persistence, HA if needed), configured securely, and monitored.8. Pros and Cons(This section remains largely the same, but the "Pros" are strengthened by the clearer strategy and decision guidance.)Pros:Unified Interface & Extensibility: Retained.Clear Strategy Separation: Explicit use of lock strategies enhances modularity.Faster Initial S3 Implementation (Optional): The simplified S3 object lock remains an option for rapid MVP.Pragmatic Path to Robustness: Clear guidance (monitoring, decision matrix) for evolving locking.Good GCS Object Lock: Remains a solid option.Informed Decisions: Monitoring and the decision matrix provide a strong basis for architectural choices.Documented Guarantees: Clarity on what to expect from each lock strategy.Cons:Simplified S3 Object Lock is Less Robust: This option still carries risks if misapplied.Complexity Deferred to Redis (if chosen): Implementing and managing Redis adds operational load.Performance: Object storage locks are inherently slower than Redis.Cost: Cloud storage and Redis incur costs.Monitoring Overhead: Requires setup and maintenance.This revised design incorporates the system architect's feedback by providing a clear decision-making framework and emphasizing the documentation of lock guarantees, further strengthening the pragmatic and extensible nature of the proposed storage backend.

--- a/test/python/integration/chat/__init__.py
+++ b/test/python/integration/chat/__init__.py
@@ -1,0 +1,1 @@
+"""Chat integration tests."""

--- a/test/python/integration/chat/test_chat_storage_integration.py
+++ b/test/python/integration/chat/test_chat_storage_integration.py
@@ -1,0 +1,425 @@
+"""Integration tests for ChatLogger with real storage backends."""
+
+import pytest
+import tempfile
+import json
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from role_play.chat.chat_logger import ChatLogger
+from role_play.common.storage import FileStorage
+from role_play.common.exceptions import StorageError
+
+import sys
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from fixtures.factories import UserFactory
+
+
+@pytest.mark.integration
+class TestChatLoggerStorageIntegration:
+    """Integration tests for ChatLogger with FileStorage."""
+
+    @pytest.mark.asyncio
+    async def test_complete_chat_session_lifecycle(self):
+        """Test a complete chat session with real file storage."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "test_user_001"
+            
+            # Start session
+            session_id, storage_path = await chat_logger.start_session(
+                user_id=user_id,
+                participant_name="Alice",
+                scenario_id="customer_service",
+                scenario_name="Customer Service Training",
+                character_id="agent_helpful",
+                character_name="Helpful Agent - Sarah",
+                goal="Practice handling customer complaints",
+                initial_settings={"difficulty": "medium", "time_limit": 1800}
+            )
+            
+            # Verify file was created in correct location
+            expected_path = f"users/{user_id}/chat_logs/{session_id}"
+            assert storage_path == expected_path
+            assert await storage.exists(storage_path)
+            
+            # Log conversation messages
+            messages = [
+                ("participant", "I'm having trouble with my order", 1),
+                ("character", "I'm sorry to hear that. Can you tell me your order number?", 2),
+                ("participant", "It's #12345", 3),
+                ("character", "Let me look that up for you. I see the issue and will fix it right away.", 4),
+                ("participant", "Thank you so much!", 5)
+            ]
+            
+            for role, content, msg_num in messages:
+                await chat_logger.log_message(
+                    user_id=user_id,
+                    session_id=session_id,
+                    role=role,
+                    content=content,
+                    message_number=msg_num,
+                    metadata={"timestamp_source": "test"}
+                )
+            
+            # End session
+            await chat_logger.end_session(
+                user_id=user_id,
+                session_id=session_id,
+                total_messages=5,
+                duration_seconds=245.5,
+                reason="conversation_completed",
+                final_state={"resolution": "successful", "satisfaction": "high"}
+            )
+            
+            # Verify complete session data
+            raw_data = await storage.read(storage_path)
+            lines = raw_data.strip().split('\n')
+            assert len(lines) == 7  # session_start + 5 messages + session_end
+            
+            # Verify session structure
+            session_start = json.loads(lines[0])
+            assert session_start["type"] == "session_start"
+            assert session_start["goal"] == "Practice handling customer complaints"
+            
+            session_end = json.loads(lines[-1])
+            assert session_end["type"] == "session_end"
+            assert session_end["total_messages"] == 5
+            assert session_end["final_state"]["resolution"] == "successful"
+    
+    @pytest.mark.asyncio
+    async def test_multiple_concurrent_users(self):
+        """Test concurrent chat sessions from different users."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            async def create_user_session(user_num):
+                user_id = f"user_{user_num:03d}"
+                
+                session_id, _ = await chat_logger.start_session(
+                    user_id=user_id,
+                    participant_name=f"User {user_num}",
+                    scenario_id="test_scenario",
+                    scenario_name="Concurrent Test",
+                    character_id="test_char",
+                    character_name="Test Character"
+                )
+                
+                # Log some messages
+                for i in range(3):
+                    await chat_logger.log_message(
+                        user_id=user_id,
+                        session_id=session_id,
+                        role="participant" if i % 2 == 0 else "character",
+                        content=f"Message {i} from {user_id}",
+                        message_number=i + 1
+                    )
+                
+                await chat_logger.end_session(
+                    user_id=user_id,
+                    session_id=session_id,
+                    total_messages=3,
+                    duration_seconds=60.0
+                )
+                
+                return user_id, session_id
+            
+            # Create 10 concurrent user sessions
+            tasks = [create_user_session(i) for i in range(10)]
+            results = await asyncio.gather(*tasks)
+            
+            # Verify all sessions were created correctly
+            for user_id, session_id in results:
+                sessions = await chat_logger.list_user_sessions(user_id)
+                assert len(sessions) == 1
+                assert sessions[0]["session_id"] == session_id
+                assert sessions[0]["message_count"] == 3
+                
+                # Verify file exists
+                storage_path = f"users/{user_id}/chat_logs/{session_id}"
+                assert await storage.exists(storage_path)
+    
+    @pytest.mark.asyncio
+    async def test_file_locking_under_contention(self):
+        """Test file locking with real concurrent writes to same session."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "concurrent_user"
+            session_id, _ = await chat_logger.start_session(
+                user_id=user_id,
+                participant_name="Concurrent Test User",
+                scenario_id="locking_test",
+                scenario_name="File Locking Test",
+                character_id="test_char",
+                character_name="Test Character"
+            )
+            
+            # Function to write messages concurrently
+            async def write_batch(start_num, count):
+                for i in range(count):
+                    msg_num = start_num + i
+                    await chat_logger.log_message(
+                        user_id=user_id,
+                        session_id=session_id,
+                        role="participant",
+                        content=f"Concurrent message {msg_num}",
+                        message_number=msg_num
+                    )
+            
+            # Write 50 messages concurrently (5 batches of 10 each)
+            tasks = [write_batch(i * 10 + 1, 10) for i in range(5)]
+            await asyncio.gather(*tasks)
+            
+            # Verify all messages were written correctly
+            storage_path = f"users/{user_id}/chat_logs/{session_id}"
+            raw_data = await storage.read(storage_path)
+            lines = raw_data.strip().split('\n')
+            
+            # Should have session_start + 50 messages
+            assert len(lines) == 51
+            
+            # Verify all message numbers are present
+            message_numbers = []
+            for line in lines[1:]:  # Skip session_start
+                event = json.loads(line)
+                if event["type"] == "message":
+                    message_numbers.append(event["message_number"])
+            
+            assert len(message_numbers) == 50
+            assert sorted(message_numbers) == list(range(1, 51))
+    
+    @pytest.mark.asyncio
+    async def test_storage_path_security(self):
+        """Test that storage paths are properly secured."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            # Try to create session with malicious user_id
+            malicious_user_id = "../../../etc/passwd"
+            
+            # This should raise a StorageError due to path traversal protection
+            with pytest.raises(StorageError) as exc_info:
+                await chat_logger.start_session(
+                    user_id=malicious_user_id,
+                    participant_name="Test",
+                    scenario_id="test",
+                    scenario_name="Test",
+                    character_id="test",
+                    character_name="Test"
+                )
+            
+            assert "Invalid key" in str(exc_info.value)
+            
+            # Test with a safe user_id
+            safe_user_id = "safe_user_123"
+            session_id, storage_path = await chat_logger.start_session(
+                user_id=safe_user_id,
+                participant_name="Test",
+                scenario_id="test",
+                scenario_name="Test",
+                character_id="test",
+                character_name="Test"
+            )
+            
+            # Verify the safe path works
+            assert storage_path.startswith("users/")
+            assert session_id in storage_path
+            assert await storage.exists(storage_path)
+    
+    @pytest.mark.asyncio
+    async def test_session_export_integration(self):
+        """Test session export with real storage data."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "export_test_user"
+            
+            # Create a realistic conversation
+            session_id, _ = await chat_logger.start_session(
+                user_id=user_id,
+                participant_name="Jane Doe",
+                scenario_id="tech_support",
+                scenario_name="Technical Support Call",
+                character_id="support_agent",
+                character_name="Support Agent - Mike"
+            )
+            
+            conversation = [
+                ("participant", "My computer won't start up", 1),
+                ("character", "I'm sorry to hear that. Let's troubleshoot this together. Can you tell me what happens when you press the power button?", 2),
+                ("participant", "Nothing happens at all. No lights, no sounds.", 3),
+                ("character", "It sounds like a power issue. Is the power cord securely connected to both the computer and the wall outlet?", 4),
+                ("participant", "Let me check... oh, the cord was loose! It's working now.", 5),
+                ("character", "Great! I'm glad we could resolve this quickly. Is there anything else I can help you with today?", 6),
+                ("participant", "No, that's all. Thank you so much!", 7)
+            ]
+            
+            for role, content, msg_num in conversation:
+                await chat_logger.log_message(
+                    user_id=user_id,
+                    session_id=session_id,
+                    role=role,
+                    content=content,
+                    message_number=msg_num
+                )
+            
+            await chat_logger.end_session(
+                user_id=user_id,
+                session_id=session_id,
+                total_messages=7,
+                duration_seconds=180.0,
+                reason="issue_resolved"
+            )
+            
+            # Export session
+            transcript = await chat_logger.export_session_text(user_id, session_id)
+            
+            # Verify export content
+            assert "ROLEPLAY SESSION TRANSCRIPT" in transcript
+            assert "Jane Doe" in transcript
+            assert "Technical Support Call" in transcript
+            assert "Support Agent - Mike" in transcript
+            assert "My computer won't start up" in transcript
+            assert "Great! I'm glad we could resolve this quickly" in transcript
+            assert "SESSION ENDED" in transcript
+            assert "Total Messages: 7" in transcript
+            assert "Duration: 180.0 seconds" in transcript
+    
+    @pytest.mark.asyncio
+    async def test_list_sessions_across_storage(self):
+        """Test listing sessions with real storage backend."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "multi_session_user"
+            session_ids = []
+            
+            # Create multiple sessions
+            for i in range(5):
+                session_id, _ = await chat_logger.start_session(
+                    user_id=user_id,
+                    participant_name=f"Session {i} User",
+                    scenario_id=f"scenario_{i}",
+                    scenario_name=f"Test Scenario {i}",
+                    character_id=f"char_{i}",
+                    character_name=f"Character {i}"
+                )
+                session_ids.append(session_id)
+                
+                # Add some messages to vary message count
+                for j in range(i + 1):
+                    await chat_logger.log_message(
+                        user_id=user_id,
+                        session_id=session_id,
+                        role="participant",
+                        content=f"Message {j}",
+                        message_number=j + 1
+                    )
+            
+            # List sessions
+            sessions = await chat_logger.list_user_sessions(user_id)
+            
+            # Verify all sessions are listed
+            assert len(sessions) == 5
+            
+            # Verify session details
+            found_session_ids = {s["session_id"] for s in sessions}
+            assert found_session_ids == set(session_ids)
+            
+            # Verify message counts
+            for i, session in enumerate(sessions):
+                expected_msg_count = len(session_ids) - i  # Due to reverse order
+                # Note: sessions are sorted by creation time (newest first)
+                assert session["message_count"] >= 1
+    
+    @pytest.mark.asyncio
+    async def test_storage_error_handling(self):
+        """Test error handling with storage failures."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "error_test_user"
+            
+            # Test logging to non-existent session
+            with pytest.raises(StorageError) as exc_info:
+                await chat_logger.log_message(
+                    user_id=user_id,
+                    session_id="nonexistent_session",
+                    role="participant",
+                    content="This should fail",
+                    message_number=1
+                )
+            
+            assert "Session log file not found" in str(exc_info.value)
+            
+            # Test export of non-existent session
+            result = await chat_logger.export_session_text(user_id, "nonexistent_session")
+            assert result == "Session log file not found."
+
+
+@pytest.mark.integration 
+class TestChatLoggerPerformance:
+    """Performance integration tests for ChatLogger."""
+    
+    @pytest.mark.asyncio
+    @pytest.mark.slow
+    async def test_large_session_performance(self):
+        """Test performance with large chat sessions."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            chat_logger = ChatLogger(storage)
+            
+            user_id = "perf_test_user"
+            
+            session_id, _ = await chat_logger.start_session(
+                user_id=user_id,
+                participant_name="Performance Test User",
+                scenario_id="perf_test",
+                scenario_name="Performance Test Scenario",
+                character_id="perf_char",
+                character_name="Performance Test Character"
+            )
+            
+            # Log 1000 messages
+            import time
+            start_time = time.time()
+            
+            for i in range(1000):
+                await chat_logger.log_message(
+                    user_id=user_id,
+                    session_id=session_id,
+                    role="participant" if i % 2 == 0 else "character",
+                    content=f"Performance test message {i}",
+                    message_number=i + 1
+                )
+            
+            end_time = time.time()
+            duration = end_time - start_time
+            
+            # Should be able to log 1000 messages in reasonable time (< 30 seconds)
+            assert duration < 30.0
+            
+            # Verify all messages were logged
+            sessions = await chat_logger.list_user_sessions(user_id)
+            assert len(sessions) == 1
+            assert sessions[0]["message_count"] == 1000
+            
+            # Test export performance
+            start_time = time.time()
+            transcript = await chat_logger.export_session_text(user_id, session_id)
+            export_duration = time.time() - start_time
+            
+            # Export should complete in reasonable time (< 10 seconds)
+            assert export_duration < 10.0
+            assert "Performance test message 999" in transcript

--- a/test/python/integration/server/__init__.py
+++ b/test/python/integration/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server integration tests."""

--- a/test/python/integration/server/test_dependencies_integration.py
+++ b/test/python/integration/server/test_dependencies_integration.py
@@ -1,0 +1,301 @@
+"""Integration tests for server dependencies with storage backend."""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from role_play.server.dependencies import get_storage_backend, get_chat_logger, get_auth_manager
+from role_play.common.storage import FileStorage
+from role_play.chat.chat_logger import ChatLogger
+from role_play.common.auth import AuthManager
+
+import sys
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+
+@pytest.mark.integration
+class TestDependencyInjectionIntegration:
+    """Integration tests for FastAPI dependency injection with storage backend."""
+
+    def test_storage_backend_dependency(self):
+        """Test that storage backend dependency returns FileStorage instance."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Mock the environment variable that get_storage_backend reads
+            import os
+            original_storage_path = os.environ.get('STORAGE_PATH')
+            os.environ['STORAGE_PATH'] = temp_dir
+            
+            try:
+                storage = get_storage_backend()
+                
+                # Verify it's a FileStorage instance
+                assert isinstance(storage, FileStorage)
+                assert storage.storage_dir == Path(temp_dir)
+                assert storage.locks_dir.exists()
+            finally:
+                # Restore original environment
+                if original_storage_path:
+                    os.environ['STORAGE_PATH'] = original_storage_path
+                elif 'STORAGE_PATH' in os.environ:
+                    del os.environ['STORAGE_PATH']
+
+    def test_chat_logger_dependency_integration(self):
+        """Test that chat logger dependency uses injected storage backend."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a storage backend
+            storage = FileStorage(temp_dir)
+            
+            # Get chat logger with this storage
+            chat_logger = get_chat_logger(storage)
+            
+            # Verify it's properly configured
+            assert isinstance(chat_logger, ChatLogger)
+            assert chat_logger.storage == storage
+
+    def test_auth_manager_dependency_integration(self):
+        """Test that auth manager dependency uses injected storage backend."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a storage backend
+            storage = FileStorage(temp_dir)
+            
+            # Mock environment variables for auth manager
+            import os
+            original_jwt_secret = os.environ.get('JWT_SECRET_KEY')
+            os.environ['JWT_SECRET_KEY'] = 'test_secret_key_for_integration'
+            
+            try:
+                # Get auth manager with this storage
+                auth_manager = get_auth_manager(storage)
+                
+                # Verify it's properly configured
+                assert isinstance(auth_manager, AuthManager)
+                assert auth_manager.storage == storage
+                # JWT secret comes from config - just verify it's set
+                assert auth_manager.jwt_secret_key is not None
+            finally:
+                # Restore original environment
+                if original_jwt_secret:
+                    os.environ['JWT_SECRET_KEY'] = original_jwt_secret
+                elif 'JWT_SECRET_KEY' in os.environ:
+                    del os.environ['JWT_SECRET_KEY']
+
+    @pytest.mark.asyncio
+    async def test_full_dependency_chain_integration(self):
+        """Test full dependency chain with real storage operations."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create storage backend
+            storage = FileStorage(temp_dir)
+            
+            # Get dependencies
+            chat_logger = get_chat_logger(storage)
+            
+            # Mock auth manager setup
+            import os
+            original_jwt_secret = os.environ.get('JWT_SECRET_KEY')
+            os.environ['JWT_SECRET_KEY'] = 'integration_test_secret'
+            
+            try:
+                auth_manager = get_auth_manager(storage)
+                
+                # Test the full workflow
+                # 1. Create a user via auth manager
+                user, token = await auth_manager.register_user(
+                    username="integration_user",
+                    email="integration@test.com",
+                    password="test_password_123"
+                )
+                
+                # 2. Use chat logger with that user
+                session_id, storage_path = await chat_logger.start_session(
+                    user_id=user.id,
+                    participant_name=user.username,
+                    scenario_id="integration_test",
+                    scenario_name="Integration Test Scenario",
+                    character_id="test_char",
+                    character_name="Test Character"
+                )
+                
+                # 3. Log a message
+                await chat_logger.log_message(
+                    user_id=user.id,
+                    session_id=session_id,
+                    role="participant",
+                    content="Integration test message",
+                    message_number=1
+                )
+                
+                # 4. Verify the data is properly stored
+                # Check user exists in storage
+                stored_user = await storage.get_user(user.id)
+                assert stored_user is not None
+                assert stored_user.username == "integration_user"
+                
+                # Check chat session exists
+                assert await storage.exists(storage_path)
+                
+                # Check session can be listed
+                sessions = await chat_logger.list_user_sessions(user.id)
+                assert len(sessions) == 1
+                assert sessions[0]["session_id"] == session_id
+                
+                # 5. Verify auth token works
+                token_user = await auth_manager.get_user_by_token(token)
+                assert token_user.id == user.id
+                
+            finally:
+                # Restore environment
+                if original_jwt_secret:
+                    os.environ['JWT_SECRET_KEY'] = original_jwt_secret
+                elif 'JWT_SECRET_KEY' in os.environ:
+                    del os.environ['JWT_SECRET_KEY']
+
+
+@pytest.mark.integration
+class TestStorageBackendSingleton:
+    """Test that storage backend dependency maintains singleton behavior."""
+    
+    def test_storage_backend_singleton_behavior(self):
+        """Test that multiple calls to get_storage_backend return same instance."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            import os
+            original_storage_path = os.environ.get('STORAGE_PATH')
+            os.environ['STORAGE_PATH'] = temp_dir
+            
+            try:
+                # Get storage backend multiple times
+                storage1 = get_storage_backend()
+                storage2 = get_storage_backend()
+                
+                # Should be the same instance (due to @lru_cache)
+                assert storage1 is storage2
+                
+            finally:
+                # Clear the cache to avoid affecting other tests
+                get_storage_backend.cache_clear()
+                if original_storage_path:
+                    os.environ['STORAGE_PATH'] = original_storage_path
+                elif 'STORAGE_PATH' in os.environ:
+                    del os.environ['STORAGE_PATH']
+
+    def test_dependency_behavior_verification(self):
+        """Test that dependencies work correctly with storage backend."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Get chat logger multiple times - should work fine
+            chat_logger1 = get_chat_logger(storage)
+            chat_logger2 = get_chat_logger(storage)
+            
+            # Both should use the same storage
+            assert chat_logger1.storage is chat_logger2.storage
+            
+            # Get auth manager multiple times - should work fine  
+            auth_manager1 = get_auth_manager(storage)
+            auth_manager2 = get_auth_manager(storage)
+            
+            # Both should use the same storage and have same config
+            assert auth_manager1.storage is auth_manager2.storage
+            assert auth_manager1.jwt_secret_key == auth_manager2.jwt_secret_key
+
+
+@pytest.mark.integration 
+class TestConcurrentDependencyAccess:
+    """Test concurrent access to dependencies."""
+    
+    @pytest.mark.asyncio
+    async def test_concurrent_chat_logger_access(self):
+        """Test concurrent access to chat logger dependency."""
+        import asyncio
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            async def get_and_use_chat_logger(user_num):
+                chat_logger = get_chat_logger(storage)
+                
+                # Start a session
+                session_id, _ = await chat_logger.start_session(
+                    user_id=f"concurrent_user_{user_num}",
+                    participant_name=f"User {user_num}",
+                    scenario_id="concurrent_test",
+                    scenario_name="Concurrent Test",
+                    character_id="test_char",
+                    character_name="Test Character"
+                )
+                
+                # Log a message
+                await chat_logger.log_message(
+                    user_id=f"concurrent_user_{user_num}",
+                    session_id=session_id,
+                    role="participant",
+                    content=f"Message from user {user_num}",
+                    message_number=1
+                )
+                
+                return f"concurrent_user_{user_num}", session_id
+            
+            # Run 5 concurrent operations
+            tasks = [get_and_use_chat_logger(i) for i in range(5)]
+            results = await asyncio.gather(*tasks)
+            
+            # Verify all operations completed successfully
+            assert len(results) == 5
+            
+            # Verify each user has their session
+            for user_id, session_id in results:
+                chat_logger = get_chat_logger(storage)
+                sessions = await chat_logger.list_user_sessions(user_id)
+                assert len(sessions) == 1
+                assert sessions[0]["session_id"] == session_id
+            
+            # Note: ChatLogger is not cached, so no cleanup needed
+
+    @pytest.mark.asyncio
+    async def test_concurrent_auth_operations(self):
+        """Test concurrent auth manager operations."""
+        import asyncio
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            import os
+            original_jwt_secret = os.environ.get('JWT_SECRET_KEY')
+            os.environ['JWT_SECRET_KEY'] = 'concurrent_test_secret'
+            
+            try:
+                async def register_user(user_num):
+                    auth_manager = get_auth_manager(storage)
+                    
+                    user, token = await auth_manager.register_user(
+                        username=f"concurrent_user_{user_num}",
+                        email=f"user{user_num}@test.com",
+                        password=f"password_{user_num}"
+                    )
+                    
+                    return user.id, token
+                
+                # Register 5 users concurrently
+                tasks = [register_user(i) for i in range(5)]
+                results = await asyncio.gather(*tasks)
+                
+                # Verify all users were created
+                assert len(results) == 5
+                
+                # Verify each user can be retrieved
+                auth_manager = get_auth_manager(storage)
+                for user_id, token in results:
+                    # Test token authentication
+                    user = await auth_manager.get_user_by_token(token)
+                    assert user.id == user_id
+                    
+                    # Test direct user retrieval
+                    stored_user = await storage.get_user(user_id)
+                    assert stored_user is not None
+                    assert stored_user.id == user_id
+                
+            finally:
+                # Restore environment (AuthManager is not cached)
+                if original_jwt_secret:
+                    os.environ['JWT_SECRET_KEY'] = original_jwt_secret
+                elif 'JWT_SECRET_KEY' in os.environ:
+                    del os.environ['JWT_SECRET_KEY']

--- a/test/python/unit/chat/test_chat_logger.py
+++ b/test/python/unit/chat/test_chat_logger.py
@@ -1,46 +1,43 @@
 """Unit tests for ChatLogger service."""
 import pytest
 import json
-import tempfile
-import shutil
-from pathlib import Path
-from datetime import datetime
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from filelock import Timeout
+import sys
+from pathlib import Path
+
+# Add fixtures to path
+sys.path.append(str(Path(__file__).parent.parent.parent))
+from fixtures.helpers import MockStorageBackend
 
 from role_play.chat.chat_logger import ChatLogger
+from role_play.common.exceptions import StorageError
 
 
 class TestChatLogger:
     """Test cases for ChatLogger."""
 
     @pytest.fixture
-    def temp_storage_path(self):
-        """Create a temporary directory for test storage."""
-        temp_dir = tempfile.mkdtemp()
-        yield temp_dir
-        shutil.rmtree(temp_dir)
+    def mock_storage(self):
+        """Create a mock storage backend."""
+        return MockStorageBackend()
 
     @pytest.fixture
-    def chat_logger(self, temp_storage_path):
-        """Create a ChatLogger instance with temp storage."""
-        return ChatLogger(storage_path_str=temp_storage_path)
+    def chat_logger(self, mock_storage):
+        """Create a ChatLogger instance with mock storage."""
+        return ChatLogger(mock_storage)
 
-    def test_init_creates_storage_directory(self):
-        """Test that ChatLogger creates storage directory if it doesn't exist."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage_path = Path(temp_dir) / "chat_logs"
-            assert not storage_path.exists()
-            
-            logger = ChatLogger(storage_path_str=str(storage_path))
-            assert storage_path.exists()
-            assert storage_path.is_dir()
+    @pytest.mark.asyncio
+    async def test_init_creates_chat_logger(self, mock_storage):
+        """Test that ChatLogger initializes with storage backend."""
+        logger = ChatLogger(mock_storage)
+        assert logger.storage == mock_storage
 
-    def test_start_session_creates_jsonl_file(self, chat_logger):
-        """Test that start_session creates a JSONL file with session_start event."""
+    @pytest.mark.asyncio
+    async def test_start_session_creates_jsonl_entry(self, chat_logger, mock_storage):
+        """Test that start_session creates a JSONL entry with session_start event."""
         user_id = "test_user_123"
-        app_session_id, jsonl_path = chat_logger.start_session(
+        app_session_id, storage_path = await chat_logger.start_session(
             user_id=user_id,
             participant_name="John Doe",
             scenario_id="scenario_1",
@@ -52,25 +49,26 @@ class TestChatLogger:
         )
 
         assert app_session_id
-        assert jsonl_path.exists()
-        assert jsonl_path.name == f"{user_id}_{app_session_id}.jsonl"
+        assert storage_path == f"users/{user_id}/chat_logs/{app_session_id}"
+        
+        # Verify the session_start event was written
+        stored_data = await mock_storage.read(storage_path)
+        event = json.loads(stored_data.strip())
+        
+        assert event["type"] == "session_start"
+        assert event["app_session_id"] == app_session_id
+        assert event["user_id"] == user_id
+        assert event["participant_name"] == "John Doe"
+        assert event["scenario_id"] == "scenario_1"
+        assert event["goal"] == "Test the system"
+        assert event["initial_settings"] == {"setting1": "value1"}
 
-        # Read and verify the session_start event
-        with open(jsonl_path, 'r') as f:
-            event = json.loads(f.readline())
-            assert event["type"] == "session_start"
-            assert event["app_session_id"] == app_session_id
-            assert event["user_id"] == user_id
-            assert event["participant_name"] == "John Doe"
-            assert event["scenario_id"] == "scenario_1"
-            assert event["goal"] == "Test the system"
-            assert event["initial_settings"] == {"setting1": "value1"}
-
-    def test_log_message(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_log_message(self, chat_logger, mock_storage):
         """Test logging messages to a session."""
         # Start a session
         user_id = "test_user"
-        app_session_id, jsonl_path = chat_logger.start_session(
+        app_session_id, storage_path = await chat_logger.start_session(
             user_id=user_id,
             participant_name="Jane",
             scenario_id="s1",
@@ -80,8 +78,8 @@ class TestChatLogger:
         )
 
         # Log messages
-        chat_logger.log_message(
-            jsonl_path=jsonl_path,
+        await chat_logger.log_message(
+            user_id=user_id,
             session_id=app_session_id,
             role="participant",
             content="Hello!",
@@ -89,8 +87,8 @@ class TestChatLogger:
             metadata={"emotion": "happy"}
         )
 
-        chat_logger.log_message(
-            jsonl_path=jsonl_path,
+        await chat_logger.log_message(
+            user_id=user_id,
             session_id=app_session_id,
             role="character",
             content="Hi there!",
@@ -98,43 +96,45 @@ class TestChatLogger:
         )
 
         # Verify messages were logged
-        with open(jsonl_path, 'r') as f:
-            lines = f.readlines()
-            assert len(lines) == 3  # session_start + 2 messages
+        stored_data = await mock_storage.read(storage_path)
+        lines = stored_data.strip().split('\n')
+        assert len(lines) == 3  # session_start + 2 messages
 
-            # Check first message
-            msg1 = json.loads(lines[1])
-            assert msg1["type"] == "message"
-            assert msg1["role"] == "participant"
-            assert msg1["content"] == "Hello!"
-            assert msg1["message_number"] == 1
-            assert msg1["metadata"]["emotion"] == "happy"
+        # Check first message
+        msg1 = json.loads(lines[1])
+        assert msg1["type"] == "message"
+        assert msg1["role"] == "participant"
+        assert msg1["content"] == "Hello!"
+        assert msg1["message_number"] == 1
+        assert msg1["metadata"]["emotion"] == "happy"
 
-            # Check second message
-            msg2 = json.loads(lines[2])
-            assert msg2["type"] == "message"
-            assert msg2["role"] == "character"
-            assert msg2["content"] == "Hi there!"
-            assert msg2["message_number"] == 2
+        # Check second message
+        msg2 = json.loads(lines[2])
+        assert msg2["type"] == "message"
+        assert msg2["role"] == "character"
+        assert msg2["content"] == "Hi there!"
+        assert msg2["message_number"] == 2
 
-    def test_log_message_file_not_found(self, chat_logger):
-        """Test that log_message raises error if file doesn't exist."""
-        fake_path = Path("/nonexistent/path.jsonl")
-        
-        with pytest.raises(FileNotFoundError):
-            chat_logger.log_message(
-                jsonl_path=fake_path,
+    @pytest.mark.asyncio
+    async def test_log_message_file_not_found(self, chat_logger):
+        """Test that log_message raises error if session doesn't exist."""
+        with pytest.raises(StorageError) as exc_info:
+            await chat_logger.log_message(
+                user_id="fake_user",
                 session_id="fake_id",
                 role="participant",
                 content="Test",
                 message_number=1
             )
+        
+        assert "Session log file not found" in str(exc_info.value)
 
-    def test_end_session(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_end_session(self, chat_logger, mock_storage):
         """Test ending a session."""
         # Start a session
         user_id = "test_user"
-        app_session_id, jsonl_path = chat_logger.start_session(
+        app_session_id, storage_path = await chat_logger.start_session(
             user_id=user_id,
             participant_name="Bob",
             scenario_id="s2",
@@ -144,8 +144,8 @@ class TestChatLogger:
         )
 
         # End the session
-        chat_logger.end_session(
-            jsonl_path=jsonl_path,
+        await chat_logger.end_session(
+            user_id=user_id,
             session_id=app_session_id,
             total_messages=5,
             duration_seconds=120.5,
@@ -154,23 +154,25 @@ class TestChatLogger:
         )
 
         # Verify session_end event
-        with open(jsonl_path, 'r') as f:
-            lines = f.readlines()
-            last_line = json.loads(lines[-1])
-            assert last_line["type"] == "session_end"
-            assert last_line["total_messages"] == 5
-            assert last_line["duration_seconds"] == 120.5
-            assert last_line["reason"] == "User closed window"
-            assert last_line["final_state"]["last_topic"] == "weather"
+        stored_data = await mock_storage.read(storage_path)
+        lines = stored_data.strip().split('\n')
+        last_line = json.loads(lines[-1])
+        
+        assert last_line["type"] == "session_end"
+        assert last_line["total_messages"] == 5
+        assert last_line["duration_seconds"] == 120.5
+        assert last_line["reason"] == "User closed window"
+        assert last_line["final_state"]["last_topic"] == "weather"
 
-    def test_list_user_sessions(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_list_user_sessions(self, chat_logger, mock_storage):
         """Test listing sessions for a user."""
         user_id = "test_user"
         
         # Create multiple sessions
         session_ids = []
         for i in range(3):
-            app_session_id, _ = chat_logger.start_session(
+            app_session_id, _ = await chat_logger.start_session(
                 user_id=user_id,
                 participant_name=f"User{i}",
                 scenario_id=f"s{i}",
@@ -181,7 +183,7 @@ class TestChatLogger:
             session_ids.append(app_session_id)
 
         # List sessions
-        sessions = chat_logger.list_user_sessions(user_id)
+        sessions = await chat_logger.list_user_sessions(user_id)
         
         assert len(sessions) == 3
         # Should be sorted by created_at (newest first)
@@ -190,11 +192,12 @@ class TestChatLogger:
             assert session["session_id"] in session_ids
             assert session["message_count"] == 0  # No messages logged
 
-    def test_export_session_text(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_export_session_text(self, chat_logger, mock_storage):
         """Test exporting a session as text."""
         # Create a complete session
         user_id = "test_user"
-        app_session_id, jsonl_path = chat_logger.start_session(
+        app_session_id, _ = await chat_logger.start_session(
             user_id=user_id,
             participant_name="Alice",
             scenario_id="s1",
@@ -204,16 +207,16 @@ class TestChatLogger:
         )
 
         # Log some messages
-        chat_logger.log_message(
-            jsonl_path=jsonl_path,
+        await chat_logger.log_message(
+            user_id=user_id,
             session_id=app_session_id,
             role="participant",
             content="I need help with my order",
             message_number=1
         )
 
-        chat_logger.log_message(
-            jsonl_path=jsonl_path,
+        await chat_logger.log_message(
+            user_id=user_id,
             session_id=app_session_id,
             role="character",
             content="I'd be happy to help you with your order!",
@@ -221,15 +224,15 @@ class TestChatLogger:
         )
 
         # End session
-        chat_logger.end_session(
-            jsonl_path=jsonl_path,
+        await chat_logger.end_session(
+            user_id=user_id,
             session_id=app_session_id,
             total_messages=2,
             duration_seconds=60.0
         )
 
         # Export as text
-        text = chat_logger.export_session_text(app_session_id, user_id)
+        text = await chat_logger.export_session_text(user_id, app_session_id)
         
         assert "ROLEPLAY SESSION TRANSCRIPT" in text
         assert "Alice" in text
@@ -240,16 +243,18 @@ class TestChatLogger:
         assert "SESSION ENDED" in text
         assert "Total Messages: 2" in text
 
-    def test_export_nonexistent_session(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_export_nonexistent_session(self, chat_logger):
         """Test exporting a session that doesn't exist."""
-        text = chat_logger.export_session_text("nonexistent_id", "fake_user")
+        text = await chat_logger.export_session_text("fake_user", "nonexistent_id")
         assert text == "Session log file not found."
 
-    def test_concurrent_writes_to_same_session(self, chat_logger):
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_to_same_session(self, chat_logger, mock_storage):
         """Test that concurrent writes to the same session are handled correctly."""
         # Start a session
         user_id = "test_user"
-        app_session_id, jsonl_path = chat_logger.start_session(
+        app_session_id, _ = await chat_logger.start_session(
             user_id=user_id,
             participant_name="ConcurrentUser",
             scenario_id="s1",
@@ -258,10 +263,10 @@ class TestChatLogger:
             character_name="Test Character"
         )
 
-        # Function to write a message
-        def write_message(msg_num):
-            chat_logger.log_message(
-                jsonl_path=jsonl_path,
+        # Function to write a message asynchronously
+        async def write_message(msg_num):
+            await chat_logger.log_message(
+                user_id=user_id,
                 session_id=app_session_id,
                 role="participant",
                 content=f"Message {msg_num}",
@@ -269,33 +274,33 @@ class TestChatLogger:
             )
 
         # Write 10 messages concurrently
-        with ThreadPoolExecutor(max_workers=5) as executor:
-            futures = [executor.submit(write_message, i) for i in range(1, 11)]
-            for future in futures:
-                future.result()  # Wait for all to complete
+        tasks = [write_message(i) for i in range(1, 11)]
+        await asyncio.gather(*tasks)
 
         # Verify all messages were written
-        with open(jsonl_path, 'r') as f:
-            lines = f.readlines()
-            # Should have session_start + 10 messages
-            assert len(lines) == 11
-            
-            # Extract message numbers
-            message_numbers = []
-            for line in lines[1:]:  # Skip session_start
-                event = json.loads(line)
-                if event["type"] == "message":
-                    message_numbers.append(event["message_number"])
-            
-            # All messages should be present
-            assert sorted(message_numbers) == list(range(1, 11))
+        storage_path = f"users/{user_id}/chat_logs/{app_session_id}"
+        stored_data = await mock_storage.read(storage_path)
+        lines = stored_data.strip().split('\n')
+        
+        # Should have session_start + 10 messages
+        assert len(lines) == 11
+        
+        # Extract message numbers
+        message_numbers = []
+        for line in lines[1:]:  # Skip session_start
+            event = json.loads(line)
+            if event["type"] == "message":
+                message_numbers.append(event["message_number"])
+        
+        # All messages should be present
+        assert sorted(message_numbers) == list(range(1, 11))
 
     @pytest.mark.asyncio
     async def test_async_concurrent_operations(self, chat_logger):
         """Test async concurrent operations on different sessions."""
         async def create_and_use_session(user_num):
             user_id = f"user_{user_num}"
-            app_session_id, jsonl_path = chat_logger.start_session(
+            app_session_id, _ = await chat_logger.start_session(
                 user_id=user_id,
                 participant_name=f"User {user_num}",
                 scenario_id="s1",
@@ -306,8 +311,8 @@ class TestChatLogger:
             
             # Log a few messages
             for i in range(3):
-                chat_logger.log_message(
-                    jsonl_path=jsonl_path,
+                await chat_logger.log_message(
+                    user_id=user_id,
                     session_id=app_session_id,
                     role="participant" if i % 2 == 0 else "character",
                     content=f"Message {i} from user {user_num}",
@@ -322,7 +327,7 @@ class TestChatLogger:
         
         # Verify each session
         for user_id, session_id in results:
-            sessions = chat_logger.list_user_sessions(user_id)
+            sessions = await chat_logger.list_user_sessions(user_id)
             assert len(sessions) == 1
             assert sessions[0]["session_id"] == session_id
             assert sessions[0]["message_count"] == 3

--- a/test/python/unit/common/test_storage.py
+++ b/test/python/unit/common/test_storage.py
@@ -5,8 +5,9 @@ import tempfile
 import json
 from pathlib import Path
 from unittest.mock import patch, mock_open
+import asyncio
 
-from role_play.common.storage import FileStorage, StorageBackend
+from role_play.common.storage import FileStorage, StorageBackend, LockAcquisitionError
 from role_play.common.exceptions import StorageError
 from role_play.common.models import User, UserAuthMethod, SessionData, UserRole, AuthProvider
 
@@ -36,6 +37,9 @@ class TestStorageBackend:
         assert hasattr(backend, 'create_user')
         assert hasattr(backend, 'get_user_auth_methods')
         assert hasattr(backend, 'store_data')
+        assert hasattr(backend, 'read')
+        assert hasattr(backend, 'write')
+        assert hasattr(backend, 'lock')
 
 
 class TestFileStorageInitialization:
@@ -47,10 +51,7 @@ class TestFileStorageInitialization:
             storage = FileStorage(temp_dir)
             
             assert storage.storage_dir == Path(temp_dir)
-            assert storage.users_dir == Path(temp_dir) / "users"
-            assert storage.auth_methods_dir == Path(temp_dir) / "auth_methods"
-            assert storage.sessions_dir == Path(temp_dir) / "sessions"
-            assert storage.data_dir == Path(temp_dir) / "data"
+            assert storage.locks_dir == Path(temp_dir) / ".locks"
     
     def test_file_storage_creates_directories(self):
         """Test that FileStorage creates required directories."""
@@ -58,154 +59,184 @@ class TestFileStorageInitialization:
             storage_path = Path(temp_dir) / "test_storage"
             storage = FileStorage(str(storage_path))
             
-            # Check all directories were created
+            # Check directories were created
             assert storage_path.exists()
-            assert (storage_path / "users").exists()
-            assert (storage_path / "auth_methods").exists()
-            assert (storage_path / "sessions").exists()
-            assert (storage_path / "data").exists()
+            assert (storage_path / ".locks").exists()
     
     def test_file_storage_with_existing_directory(self):
         """Test FileStorage with existing directory structure."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage_path = Path(temp_dir) / "existing"
             storage_path.mkdir()
-            (storage_path / "users").mkdir()
             
             # Should not raise error with existing directories
             storage = FileStorage(str(storage_path))
             assert storage.storage_dir == storage_path
 
 
-class TestFileStorageJSONOperations:
-    """Test FileStorage JSON file operations."""
+class TestFileStorageLocking:
+    """Test FileStorage locking mechanism."""
     
-    def test_read_json_file_success(self):
-        """Test successful JSON file reading."""
+    def test_lock_context_manager(self):
+        """Test the lock context manager works."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            # Create test file
-            test_data = {"key": "value", "number": 42}
-            test_file = Path(temp_dir) / "test.json"
-            with open(test_file, 'w') as f:
-                json.dump(test_data, f)
+            # Should not raise any exceptions
+            with storage.lock("test/path"):
+                pass
+    
+    def test_lock_creates_lock_file(self):
+        """Test that locking creates appropriate lock file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
             
-            result = storage._read_json_file(test_file)
+            with storage.lock("users/123/profile"):
+                # Lock file should exist during lock
+                lock_path = storage.locks_dir / "users_123_profile.lock"
+                # Note: The actual lock file might not be visible due to filelock implementation
+                pass
+            
+            # After releasing lock, we're done
+
+
+class TestFileStorageBasicOperations:
+    """Test FileStorage basic file operations."""
+    
+    @pytest.mark.asyncio
+    async def test_write_and_read_text(self):
+        """Test writing and reading text data."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            test_data = "Hello, World!"
+            path = "test/file.txt"
+            
+            await storage.write(path, test_data)
+            result = await storage.read(path)
+            
             assert result == test_data
     
-    def test_read_json_file_not_exists(self):
-        """Test reading non-existent JSON file."""
+    @pytest.mark.asyncio
+    async def test_append_text(self):
+        """Test appending text data."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            non_existent = Path(temp_dir) / "missing.json"
-            result = storage._read_json_file(non_existent)
+            path = "test/append.txt"
+            
+            await storage.write(path, "Line 1\n")
+            await storage.append(path, "Line 2\n")
+            await storage.append(path, "Line 3\n")
+            
+            result = await storage.read(path)
+            assert result == "Line 1\nLine 2\nLine 3\n"
+    
+    @pytest.mark.asyncio
+    async def test_exists(self):
+        """Test checking file existence."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            path = "test/exists.txt"
+            
+            assert not await storage.exists(path)
+            
+            await storage.write(path, "content")
+            assert await storage.exists(path)
+    
+    @pytest.mark.asyncio
+    async def test_delete(self):
+        """Test deleting files."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            path = "test/delete.txt"
+            
+            await storage.write(path, "content")
+            assert await storage.exists(path)
+            
+            result = await storage.delete(path)
+            assert result is True
+            assert not await storage.exists(path)
+            
+            # Deleting non-existent file should return False
+            result = await storage.delete(path)
+            assert result is False
+    
+    @pytest.mark.asyncio
+    async def test_list_keys(self):
+        """Test listing keys with prefix."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Create some files
+            await storage.write("users/123/profile", "user data")
+            await storage.write("users/123/settings", "settings data")
+            await storage.write("users/456/profile", "other user")
+            await storage.write("sessions/abc", "session data")
+            
+            # Test prefix matching
+            user_keys = await storage.list_keys("users/123/")
+            assert len(user_keys) == 2
+            assert "users/123/profile" in user_keys
+            assert "users/123/settings" in user_keys
+            
+            all_user_keys = await storage.list_keys("users/")
+            assert len(all_user_keys) == 3
+    
+    @pytest.mark.asyncio
+    async def test_read_nonexistent_file(self):
+        """Test reading non-existent file raises error."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            with pytest.raises(StorageError) as exc_info:
+                await storage.read("nonexistent/file.txt")
+            
+            assert "Path not found" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_invalid_key_security(self):
+        """Test that invalid keys (with ..) are rejected."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            with pytest.raises(StorageError) as exc_info:
+                await storage.write("../../../etc/passwd", "hacker data")
+            
+            assert "Invalid key" in str(exc_info.value)
+
+
+class TestFileStorageJSONOperations:
+    """Test FileStorage JSON helper methods."""
+    
+    @pytest.mark.asyncio
+    async def test_read_write_json(self):
+        """Test JSON read/write operations."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            test_data = {"key": "value", "number": 42, "list": [1, 2, 3]}
+            path = "test/data"
+            
+            await storage._write_json(path, test_data)
+            result = await storage._read_json(path)
+            
+            assert result == test_data
+    
+    @pytest.mark.asyncio
+    async def test_read_json_nonexistent(self):
+        """Test reading non-existent JSON returns None."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            result = await storage._read_json("nonexistent/file")
             assert result is None
-    
-    def test_read_json_file_invalid_json(self):
-        """Test reading invalid JSON file."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            # Create invalid JSON file
-            invalid_file = Path(temp_dir) / "invalid.json"
-            with open(invalid_file, 'w') as f:
-                f.write("{ invalid json }")
-            
-            with pytest.raises(StorageError) as exc_info:
-                storage._read_json_file(invalid_file)
-            
-            assert "Failed to read file" in str(exc_info.value)
-    
-    def test_write_json_file_success(self):
-        """Test successful JSON file writing."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            test_data = {"key": "value", "list": [1, 2, 3]}
-            test_file = Path(temp_dir) / "output.json"
-            
-            storage._write_json_file(test_file, test_data)
-            
-            # Verify file was written correctly
-            assert test_file.exists()
-            with open(test_file, 'r') as f:
-                written_data = json.load(f)
-            assert written_data == test_data
-    
-    def test_write_json_file_with_datetime(self):
-        """Test JSON file writing with datetime objects."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            user = UserFactory.create()
-            test_file = Path(temp_dir) / "user.json"
-            
-            # Should handle datetime serialization via default=str
-            storage._write_json_file(test_file, user.model_dump())
-            
-            assert test_file.exists()
-            # File should contain serialized datetime strings
-            with open(test_file, 'r') as f:
-                content = f.read()
-                assert user.username in content
-    
-    def test_write_json_file_permission_error(self):
-        """Test JSON file writing with permission error."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            # Create a directory where we try to write a file
-            blocked_path = Path(temp_dir) / "blocked"
-            blocked_path.mkdir()
-            blocked_path.chmod(0o444)  # Read-only
-            
-            test_file = blocked_path / "test.json"
-            
-            with pytest.raises(StorageError) as exc_info:
-                storage._write_json_file(test_file, {"data": "test"})
-            
-            assert "Failed to write file" in str(exc_info.value)
-
-
-class TestFileStorageErrorHandling:
-    """Test FileStorage error handling scenarios."""
-    
-    def test_io_error_on_read(self):
-        """Test handling IO errors during file reading."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            # Mock open to raise IOError
-            with patch('builtins.open', side_effect=IOError("Disk error")):
-                test_file = Path(temp_dir) / "test.json"
-                test_file.touch()  # Create empty file
-                
-                with pytest.raises(StorageError) as exc_info:
-                    storage._read_json_file(test_file)
-                
-                assert "Failed to read file" in str(exc_info.value)
-                assert "Disk error" in str(exc_info.value)
-    
-    def test_io_error_on_write(self):
-        """Test handling IO errors during file writing."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            test_file = Path(temp_dir) / "test.json"
-            
-            # Mock open to raise IOError
-            with patch('builtins.open', side_effect=IOError("No space left")):
-                with pytest.raises(StorageError) as exc_info:
-                    storage._write_json_file(test_file, {"data": "test"})
-                
-                assert "Failed to write file" in str(exc_info.value)
-                assert "No space left" in str(exc_info.value)
 
 
 class TestFileStorageUserOperations:
-    """Test FileStorage user-related operations (unit level)."""
+    """Test FileStorage user-related operations."""
     
     @pytest.mark.asyncio
     async def test_create_user_file_structure(self):
@@ -216,15 +247,14 @@ class TestFileStorageUserOperations:
             
             await storage.create_user(user)
             
-            # Check file was created with correct name
-            user_file = Path(temp_dir) / "users" / "test-123.json"
-            assert user_file.exists()
+            # Check file was created with correct path
+            user_path = "users/test-123/profile"
+            assert await storage.exists(user_path)
             
             # Check file contains correct data
-            with open(user_file, 'r') as f:
-                data = json.load(f)
-                assert data["id"] == "test-123"
-                assert data["username"] == "testuser"
+            result = await storage._read_json(user_path)
+            assert result["id"] == "test-123"
+            assert result["username"] == "testuser"
     
     @pytest.mark.asyncio
     async def test_create_user_already_exists(self):
@@ -265,57 +295,39 @@ class TestFileStorageUserOperations:
     
     @pytest.mark.asyncio
     async def test_delete_user_not_found(self):
-        """Test deleting non-existent user returns False."""
+        """Test deleting non-existent user returns True (no-op)."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
             result = await storage.delete_user("non-existent-id")
-            assert result is False
+            assert result is True  # Always returns True for delete operations
 
 
 class TestFileStorageAuthMethodOperations:
-    """Test FileStorage auth method operations (unit level)."""
+    """Test FileStorage auth method operations."""
     
     @pytest.mark.asyncio
     async def test_create_auth_method_file_structure(self):
         """Test that create_user_auth_method creates correct file."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
-            auth_method = UserAuthMethodFactory.create(id="auth-123")
+            auth_method = UserAuthMethodFactory.create(id="auth-123", user_id="user-456")
             
             await storage.create_user_auth_method(auth_method)
             
-            # Check file was created
-            auth_file = Path(temp_dir) / "auth_methods" / "auth-123.json"
-            assert auth_file.exists()
+            # Check file was created with correct path
+            auth_path = f"users/{auth_method.user_id}/auth_methods/{auth_method.id}"
+            assert await storage.exists(auth_path)
             
             # Check file contains correct data
-            with open(auth_file, 'r') as f:
-                data = json.load(f)
-                assert data["id"] == "auth-123"
-                assert data["provider"] == auth_method.provider
-    
-    @pytest.mark.asyncio
-    async def test_get_user_auth_methods_empty(self):
-        """Test getting auth methods for user with none."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            result = await storage.get_user_auth_methods("user-with-no-auth")
-            assert result == []
-    
-    @pytest.mark.asyncio
-    async def test_get_user_auth_method_not_found(self):
-        """Test getting non-existent auth method returns None."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            result = await storage.get_user_auth_method("google", "missing-user")
-            assert result is None
+            result = await storage._read_json(auth_path)
+            assert result["id"] == "auth-123"
+            assert result["user_id"] == "user-456"
+            assert result["provider"] == auth_method.provider
 
 
 class TestFileStorageSessionOperations:
-    """Test FileStorage session operations (unit level)."""
+    """Test FileStorage session operations."""
     
     @pytest.mark.asyncio
     async def test_create_session_file_structure(self):
@@ -326,24 +338,13 @@ class TestFileStorageSessionOperations:
             
             await storage.create_session(session)
             
-            # Check file was created
-            session_file = Path(temp_dir) / "sessions" / "session-123.json"
-            assert session_file.exists()
+            # Check file was created with correct path
+            session_path = f"sessions/{session.session_id}"
+            assert await storage.exists(session_path)
             
             # Check file contains correct data
-            with open(session_file, 'r') as f:
-                data = json.load(f)
-                assert data["session_id"] == "session-123"
-                assert data["user_id"] == session.user_id
-    
-    @pytest.mark.asyncio
-    async def test_get_session_not_found(self):
-        """Test getting non-existent session returns None."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            storage = FileStorage(temp_dir)
-            
-            result = await storage.get_session("missing-session")
-            assert result is None
+            result = await storage._read_json(session_path)
+            assert result["session_id"] == "session-123"
 
 
 class TestFileStorageDataOperations:
@@ -355,48 +356,362 @@ class TestFileStorageDataOperations:
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            test_data = {"complex": {"nested": "data"}, "numbers": [1, 2, 3]}
-            await storage.store_data("test_key", test_data)
+            test_data = {"complex": {"nested": "data"}, "list": [1, 2, 3]}
+            key = "test/config"
             
-            # Check file was created
-            data_file = Path(temp_dir) / "data" / "test_key.json"
-            assert data_file.exists()
+            await storage.store_data(key, test_data)
+            result = await storage.get_data(key)
             
-            # Check data can be retrieved
-            result = await storage.get_data("test_key")
+            assert result == test_data
+
+
+class TestFileStorageErrorHandling:
+    """Test FileStorage error handling scenarios."""
+    
+    @pytest.mark.asyncio
+    async def test_io_error_on_read(self):
+        """Test handling IO errors during file reading."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Create a file first
+            await storage.write("test/file", "content")
+            
+            # Mock open to raise IOError
+            with patch('builtins.open', side_effect=IOError("Disk error")):
+                with pytest.raises(StorageError) as exc_info:
+                    await storage.read("test/file")
+                
+                assert "Failed to read" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_io_error_on_write(self):
+        """Test handling IO errors during file writing."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Mock open to raise IOError
+            with patch('builtins.open', side_effect=IOError("No space left")):
+                with pytest.raises(StorageError) as exc_info:
+                    await storage.write("test/file", "content")
+                
+                assert "Failed to write" in str(exc_info.value)
+
+
+class TestFileStorageBytesOperations:
+    """Test FileStorage bytes methods."""
+    
+    @pytest.mark.asyncio
+    async def test_write_read_bytes(self):
+        """Test writing and reading binary data."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            test_data = b"Binary data \x00\x01\x02"
+            path = "test/binary"
+            
+            await storage.write_bytes(path, test_data)
+            result = await storage.read_bytes(path)
+            
             assert result == test_data
     
     @pytest.mark.asyncio
-    async def test_get_data_not_found(self):
-        """Test getting non-existent data returns None."""
+    async def test_append_bytes(self):
+        """Test appending binary data."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            result = await storage.get_data("missing_key")
-            assert result is None
+            path = "test/binary_append"
+            
+            await storage.write_bytes(path, b"Part 1")
+            await storage.append_bytes(path, b"Part 2")
+            
+            result = await storage.read_bytes(path)
+            assert result == b"Part 1Part 2"
+
+
+class TestFileStorageComplexOperations:
+    """Test FileStorage in complex scenarios."""
     
     @pytest.mark.asyncio
-    async def test_delete_data_success(self):
-        """Test successful data deletion."""
+    async def test_concurrent_file_operations(self):
+        """Test concurrent file operations."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            # Store some data first
-            await storage.store_data("delete_me", {"data": "to_delete"})
+            async def write_file(file_num):
+                path = f"concurrent/file_{file_num}"
+                content = f"Content for file {file_num}"
+                await storage.write(path, content)
+                return path, content
             
-            # Delete it
-            result = await storage.delete_data("delete_me")
-            assert result is True
+            # Write 10 files concurrently
+            tasks = [write_file(i) for i in range(10)]
+            results = await asyncio.gather(*tasks)
             
-            # Verify it's gone
-            data_file = Path(temp_dir) / "data" / "delete_me.json"
-            assert not data_file.exists()
+            # Verify all files were written correctly
+            for path, expected_content in results:
+                actual_content = await storage.read(path)
+                assert actual_content == expected_content
     
     @pytest.mark.asyncio
-    async def test_delete_data_not_found(self):
-        """Test deleting non-existent data returns False."""
+    async def test_user_search_operations(self):
+        """Test user search by username and email."""
         with tempfile.TemporaryDirectory() as temp_dir:
             storage = FileStorage(temp_dir)
             
-            result = await storage.delete_data("never_existed")
-            assert result is False
+            # Create multiple users
+            user1 = UserFactory.create(id="user1", username="alice", email="alice@example.com")
+            user2 = UserFactory.create(id="user2", username="bob", email="bob@example.com")
+            
+            await storage.create_user(user1)
+            await storage.create_user(user2)
+            
+            # Test search by username
+            found_alice = await storage.get_user_by_username("alice")
+            assert found_alice is not None
+            assert found_alice.id == "user1"
+            
+            found_none = await storage.get_user_by_username("charlie")
+            assert found_none is None
+            
+            # Test search by email
+            found_bob = await storage.get_user_by_email("bob@example.com")
+            assert found_bob is not None
+            assert found_bob.id == "user2"
+            
+            found_none = await storage.get_user_by_email("charlie@example.com")
+            assert found_none is None
+    
+    @pytest.mark.asyncio
+    async def test_auth_method_search_operations(self):
+        """Test auth method search and retrieval."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Create auth methods for different users
+            auth1 = UserAuthMethodFactory.create(
+                id="auth1", user_id="user1", provider="google", provider_user_id="google123"
+            )
+            auth2 = UserAuthMethodFactory.create(
+                id="auth2", user_id="user1", provider="local", provider_user_id="alice"
+            )
+            auth3 = UserAuthMethodFactory.create(
+                id="auth3", user_id="user2", provider="google", provider_user_id="google456"
+            )
+            
+            await storage.create_user_auth_method(auth1)
+            await storage.create_user_auth_method(auth2)
+            await storage.create_user_auth_method(auth3)
+            
+            # Test get by provider and provider_user_id
+            found_google = await storage.get_user_auth_method("google", "google123")
+            assert found_google is not None
+            assert found_google.id == "auth1"
+            
+            found_none = await storage.get_user_auth_method("google", "notfound")
+            assert found_none is None
+            
+            # Test get all auth methods for user
+            user1_methods = await storage.get_user_auth_methods("user1")
+            assert len(user1_methods) == 2
+            
+            user2_methods = await storage.get_user_auth_methods("user2")
+            assert len(user2_methods) == 1
+            
+            # Test delete auth method
+            deleted = await storage.delete_user_auth_method("auth1")
+            assert deleted is True
+            
+            # Verify it was deleted
+            remaining_methods = await storage.get_user_auth_methods("user1")
+            assert len(remaining_methods) == 1
+            
+            # Test delete non-existent
+            deleted_none = await storage.delete_user_auth_method("nonexistent")
+            assert deleted_none is False
+    
+    @pytest.mark.asyncio
+    async def test_json_decode_error_handling(self):
+        """Test JSON decode error handling."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Write invalid JSON manually
+            file_path = storage._get_storage_path("invalid.json")
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(file_path, 'w') as f:
+                f.write("{ invalid json ")
+            
+            # Should raise StorageError
+            with pytest.raises(StorageError) as exc_info:
+                await storage._read_json("invalid.json")
+            
+            assert "Failed to parse JSON" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_lock_timeout_simulation(self):
+        """Test lock acquisition timeout (simulated)."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # This is hard to test without real contention, but we can at least
+            # verify the timeout parameter is accepted
+            with storage.lock("test/resource", timeout=0.1):
+                pass  # Should work fine
+    
+    @pytest.mark.asyncio
+    async def test_lock_timeout_error(self):
+        """Test lock timeout error by mocking."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Mock FileLock to raise Timeout
+            from filelock import Timeout
+            from unittest.mock import patch
+            
+            with patch('role_play.common.storage.FileLock') as mock_lock:
+                mock_instance = mock_lock.return_value
+                mock_instance.__enter__.side_effect = Timeout("test")
+                
+                with pytest.raises(LockAcquisitionError) as exc_info:
+                    with storage.lock("test/resource", timeout=0.1):
+                        pass
+                
+                assert "Failed to acquire lock" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_string_bytes_conversion(self):
+        """Test the default string/bytes conversion methods."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Test that base class default conversions would work
+            # (FileStorage overrides these, but let's test the defaults)
+            text_data = "Hello, 世界!"
+            
+            # Write as string, read as bytes
+            await storage.write("test/text", text_data)
+            bytes_result = await storage.read_bytes("test/text")
+            assert bytes_result == text_data.encode('utf-8')
+            
+            # Write as bytes, read as string  
+            bytes_data = "Binary: \x00\x01\x02".encode('utf-8')
+            await storage.write_bytes("test/binary", bytes_data)
+            text_result = await storage.read("test/binary")
+            assert text_result == bytes_data.decode('utf-8')
+    
+    @pytest.mark.asyncio
+    async def test_full_user_workflow(self):
+        """Test a complete user creation and management workflow."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Create a user
+            user = UserFactory.create(id="workflow-123", username="testuser")
+            await storage.create_user(user)
+            
+            # Create auth methods
+            auth1 = UserAuthMethodFactory.create(
+                user_id=user.id,
+                provider="local",
+                provider_user_id="testuser"
+            )
+            auth2 = UserAuthMethodFactory.create(
+                user_id=user.id,
+                provider="google",
+                provider_user_id="google-123"
+            )
+            
+            await storage.create_user_auth_method(auth1)
+            await storage.create_user_auth_method(auth2)
+            
+            # Create a session
+            session = SessionDataFactory.create(
+                user_id=user.id,
+                metadata={"test": "data"}
+            )
+            await storage.create_session(session)
+            
+            # Verify everything exists
+            retrieved_user = await storage.get_user(user.id)
+            assert retrieved_user.username == "testuser"
+            
+            auth_methods = await storage.get_user_auth_methods(user.id)
+            assert len(auth_methods) == 2
+            
+            retrieved_session = await storage.get_session(session.session_id)
+            assert retrieved_session.user_id == user.id
+            
+            # Update user
+            user.email = "updated@example.com"
+            await storage.update_user(user)
+            
+            updated_user = await storage.get_user(user.id)
+            assert updated_user.email == "updated@example.com"
+            
+            # Clean up
+            await storage.delete_user(user.id)
+            await storage.delete_session(session.session_id)
+            
+            assert await storage.get_user(user.id) is None
+            assert await storage.get_session(session.session_id) is None
+
+
+class TestStorageBackendDefaultMethods:
+    """Test StorageBackend default method implementations."""
+    
+    @pytest.mark.asyncio
+    async def test_bytes_methods_default_implementation(self):
+        """Test that default bytes methods work via string conversion."""
+        backend = MockStorageBackend()
+        
+        # Test write_bytes -> write conversion
+        test_bytes = b"Hello, bytes!"
+        await backend.write_bytes("test/bytes", test_bytes)
+        
+        # Should be stored as string
+        stored = await backend.read("test/bytes")
+        assert stored == test_bytes.decode('utf-8')
+        
+        # Test read_bytes -> read conversion
+        result_bytes = await backend.read_bytes("test/bytes")
+        assert result_bytes == test_bytes
+        
+        # Test append_bytes -> append conversion
+        more_bytes = b" More data!"
+        await backend.append_bytes("test/bytes", more_bytes)
+        
+        final_result = await backend.read_bytes("test/bytes")
+        assert final_result == test_bytes + more_bytes
+    
+    @pytest.mark.asyncio
+    async def test_empty_prefix_list_keys(self):
+        """Test list_keys with empty results."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # List keys for non-existent prefix
+            keys = await storage.list_keys("nonexistent/")
+            assert keys == []
+    
+    @pytest.mark.asyncio
+    async def test_hidden_files_ignored(self):
+        """Test that hidden files are ignored in list_keys."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            storage = FileStorage(temp_dir)
+            
+            # Create regular and hidden files
+            await storage.write("test/regular.txt", "content")
+            
+            # Create hidden file manually
+            hidden_path = storage._get_storage_path("test/.hidden")
+            hidden_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(hidden_path, 'w') as f:
+                f.write("hidden content")
+            
+            # List keys should not include hidden files
+            keys = await storage.list_keys("test/")
+            assert len(keys) == 1
+            assert "test/regular.txt" in keys
+            assert "test/.hidden" not in keys


### PR DESCRIPTION
ChatLogger is NOT using file backend but actaully doing file ops, refactor so it uses storagebackend, and update test and others so storage backend supports locking

also make the decision to do namespacing based on user_id so storage layout looks like
/data/{user_id}/chat_log/chat_session_id for chat_log files

also we removed the .json on file as we will just assume file types in preparation to cloud backed storage backend