### PR TITLE
Fix local development by adding Vite proxy for API routes

### DIFF
--- a/src/ts/role_play/ui/vite.config.js
+++ b/src/ts/role_play/ui/vite.config.js
@@ -8,6 +8,9 @@ export default defineConfig({
     cors: true,
     // Use 0.0.0.0 for dev server (works in containers and locally)
     // In production, this won't be used as the app will be built and served statically
-    host: '0.0.0.0'
+    host: '0.0.0.0',
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
   }
 })


### PR DESCRIPTION
Recent deployment changes introduced centralized API configuration with `/api` prefix, breaking local development where frontend (port 3000) needs to proxy API calls to backend (port 8000). This change is development-only and does not affect production.

🤖 Generated with [Claude Code](https://claude.ai/code)