### PR TITLE
fix Score not serializable issue on gcs

### DIFF
--- a/src/python/role_play/evaluation/handler.py
+++ b/src/python/role_play/evaluation/handler.py
@@ -312,11 +312,11 @@ class EvaluationHandler(BaseHandler):
                 "user_id": current_user.id,
                 "created_at": timestamp,
                 "evaluation_type": request.evaluation_type,
-                "report": report_response.model_dump()
+                "report": report_response.model_dump(mode="json")
             }
             
             try:
-                await storage.write(report_path, json.dumps(report_data, indent=2))
+                await storage.write(report_path, json.dumps(report_data, sort_keys=True))
                 logger.info(f"Stored evaluation report at {report_path}")
             except Exception as store_err:
                 # Log error but don't fail the request since report was generated


### PR DESCRIPTION
## summary
in #30 somehow only on gcs there is an issue with pydantic `model_dump()`, this PR updates to `model_dump(mode="json")` to get something that is safly json-serializable later

## test
deployed to beta and tested on gcs

## todo
need to figure out proper dev test for this