### PR TITLE
Add script-based roleplay support

### DIFF
--- a/src/python/role_play/chat/chat_logger.py
+++ b/src/python/role_play/chat/chat_logger.py
@@ -232,7 +232,10 @@ class ChatLogger:
                             "character_name": start_event.get("character_name"),
                             "created_at": start_event.get("timestamp"),
                             "storage_path": log_key,
-                            "message_count": message_count
+                            "message_count": message_count,
+                            "goal": start_event.get("goal"),
+                            "script_id": start_event.get("initial_settings", {}).get("script_id"),
+                            "script_progress": start_event.get("initial_settings", {}).get("script_progress", 0)
                         })
             except Exception as e:
                 logger.error(f"Error reading session summary from {log_key}: {e}")

--- a/src/python/role_play/chat/models.py
+++ b/src/python/role_play/chat/models.py
@@ -8,6 +8,7 @@ class CreateSessionRequest(BaseModel):
     scenario_id: str
     character_id: str
     participant_name: str
+    script_id: Optional[str] = Field(default=None)
 
 class CreateSessionResponse(BaseResponse):
     """Response after creating a chat session."""
@@ -37,6 +38,8 @@ class SessionInfo(BaseModel):
     jsonl_filename: str
     is_active: bool = True  # Whether session exists in InMemorySessionService
     goal: Optional[str] = Field(default=None, description="Goal of this session, could be written in local language.")
+    script_id: Optional[str] = None
+    script_progress: int = 0
     ended_at: Optional[str] = None
     ended_reason: Optional[str] = None
 

--- a/src/python/role_play/common/models.py
+++ b/src/python/role_play/common/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from pydantic import BaseModel, Field
 
 
@@ -130,3 +130,15 @@ class Environment(str, Enum):
     DEV = "dev"
     BETA = "beta"
     PROD = "prod"
+
+
+class Script(BaseModel):
+    """Pre-written script for guided roleplay sessions."""
+
+    id: str
+    scenario_id: str
+    character_id: str
+    language: str = Field(default="en")
+    goal: str
+    script: List[Dict[str, str]]  # {"speaker": str, "line": str} or {"speaker": "llm", "action": "stop"}
+

--- a/src/python/role_play/resources/scenarios.json
+++ b/src/python/role_play/resources/scenarios.json
@@ -44,5 +44,20 @@
       "description": "Elderly customer needing help",
       "system_prompt": "You are Betty, a 70-year-old customer confused about a product. Ask lots of questions and need step-by-step explanations. Be polite but easily overwhelmed."
     }
+  ],
+  "scripts": [
+    {
+      "id": "medical_acute_frustration_simple",
+      "scenario_id": "medical_interview",
+      "character_id": "patient_acute",
+      "language": "en",
+      "goal": "Practice handling a patient who is downplaying their pain.",
+      "script": [
+        { "speaker": "character", "line": "I'm fine, doc. Just a little tweak." },
+        { "speaker": "participant", "line": "Describe the pain for me." },
+        { "speaker": "character", "line": "(Sighs) Okay, it's more of a sharp pain. A 6 or 7 maybe." },
+        { "speaker": "llm", "action": "stop" }
+      ]
+    }
   ]
 }

--- a/test/python/unit/chat/test_script_support.py
+++ b/test/python/unit/chat/test_script_support.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from role_play.common.models import Script
+from role_play.chat.content_loader import ContentLoader
+from role_play.chat.handler import ChatHandler
+from role_play.chat.models import CreateSessionRequest
+
+
+def test_script_model_validation():
+    data = {
+        "id": "s1",
+        "scenario_id": "medical_interview",
+        "character_id": "patient_acute",
+        "goal": "Test",
+        "script": [
+            {"speaker": "character", "line": "hi"},
+            {"speaker": "llm", "action": "stop"}
+        ]
+    }
+    script = Script(**data)
+    assert script.id == "s1"
+    assert script.language == "en"
+
+
+def test_content_loader_scripts():
+    loader = ContentLoader(supported_languages=["en"])
+    scripts = loader.get_scripts("en")
+    assert isinstance(scripts, list)
+    if scripts:
+        script = loader.get_script_by_id(scripts[0]["id"], "en")
+        assert script["id"] == scripts[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_session_invalid_script():
+    handler = ChatHandler()
+    mock_user = Mock()
+    mock_user.id = "user1"
+    mock_user.preferred_language = "en"
+
+    chat_logger = AsyncMock()
+    session_service = AsyncMock()
+    loader = Mock()
+    loader.get_scenario_by_id.return_value = {"id": "sc1", "name": "Scenario", "compatible_characters": ["char"]}
+    loader.get_character_by_id.return_value = {"id": "char", "name": "Char"}
+    loader.get_script_by_id.return_value = None
+
+    req = CreateSessionRequest(scenario_id="sc1", character_id="char", participant_name="P1", script_id="bad")
+
+    with pytest.raises(Exception):
+        await handler.create_session(
+            request=req,
+            current_user=mock_user,
+            chat_logger=chat_logger,
+            adk_session_service=session_service,
+            content_loader=loader,
+        )
+


### PR DESCRIPTION
## Summary
- define `Script` model and allow sessions to reference scripts
- extend session models with script info
- add scripts to content loader with language filtering helpers
- validate scripts and track progress in `ChatHandler`
- include script metadata in session summaries
- update resources with example script
- add unit and integration tests for script support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b1bbd1a08329b2f2db98643931e0