### PR TITLE
Add script resource support to roleplay chat

### DIFF
--- a/data/resources/scripts/scripts.json
+++ b/data/resources/scripts/scripts.json
@@ -1,0 +1,20 @@
+{
+  "resource_version": "1.0",
+  "last_modified": "2025-07-29T01:37:13Z",
+  "modified_by": "manual",
+  "scripts": [
+    {
+      "id": "medical_acute_frustration_simple",
+      "scenario_id": "medical_interview",
+      "character_id": "patient_acute",
+      "language": "en",
+      "goal": "Practice handling a patient who is downplaying their pain.",
+      "script": [
+        { "speaker": "character", "line": "I'm fine, doc. Just a little tweak." },
+        { "speaker": "participant", "line": "Describe the pain for me." },
+        { "speaker": "character", "line": "(Sighs) Okay, it's more of a sharp pain. A 6 or 7 maybe." },
+        { "speaker": "llm", "action": "stop" }
+      ]
+    }
+  ]
+}

--- a/data/resources/scripts/scripts_zh-TW.json
+++ b/data/resources/scripts/scripts_zh-TW.json
@@ -1,0 +1,20 @@
+{
+  "resource_version": "1.0",
+  "last_modified": "2025-07-29T01:37:13Z",
+  "modified_by": "manual",
+  "scripts": [
+    {
+      "id": "medical_acute_frustration_simple_zh_tw",
+      "scenario_id": "medical_interview_zh_tw",
+      "character_id": "patient_acute_zh_tw",
+      "language": "zh-TW",
+      "goal": "練習處理病患輕描淡寫疼痛的情況。",
+      "script": [
+        { "speaker": "character", "line": "醫生，我沒事啦，只是小扭傷而已。" },
+        { "speaker": "participant", "line": "請形容一下你的疼痛。" },
+        { "speaker": "character", "line": "（嘆氣）好吧，是比較尖銳的痛，大概六、七分吧。" },
+        { "speaker": "llm", "action": "stop" }
+      ]
+    }
+  ]
+}

--- a/src/python/role_play/chat/models.py
+++ b/src/python/role_play/chat/models.py
@@ -8,6 +8,7 @@ class CreateSessionRequest(BaseModel):
     scenario_id: str
     character_id: str
     participant_name: str
+    script_id: Optional[str] = Field(default=None, description="Optional script to use for the session")
 
 class CreateSessionResponse(BaseResponse):
     """Response after creating a chat session."""

--- a/src/python/role_play/common/resource_loader.py
+++ b/src/python/role_play/common/resource_loader.py
@@ -107,6 +107,10 @@ class ResourceLoader:
         """Loads all characters for a specific language."""
         return await self._get_all_from_resource_type("characters", language)
 
+    async def get_scripts(self, language: str = "en") -> list[dict]:
+        """Loads all scripts for a specific language."""
+        return await self._get_all_from_resource_type("scripts", language)
+
     async def get_scenario_by_id(self, scenario_id: str, language: str = "en") -> dict | None:
         """Gets a single scenario by its ID for the specified language."""
         scenarios = await self.get_scenarios(language)
@@ -116,4 +120,9 @@ class ResourceLoader:
         """Gets a single character by its ID for the specified language."""
         characters = await self.get_characters(language)
         return next((c for c in characters if c.get("id") == character_id), None)
+
+    async def get_script_by_id(self, script_id: str, language: str = "en") -> dict | None:
+        """Gets a single script by its ID for the specified language."""
+        scripts = await self.get_scripts(language)
+        return next((s for s in scripts if s.get("id") == script_id), None)
 

--- a/src/resources/scripts/scripts.json
+++ b/src/resources/scripts/scripts.json
@@ -1,0 +1,20 @@
+{
+  "resource_version": "1.0",
+  "last_modified": "2025-07-29T01:37:13Z",
+  "modified_by": "manual",
+  "scripts": [
+    {
+      "id": "medical_acute_frustration_simple",
+      "scenario_id": "medical_interview",
+      "character_id": "patient_acute",
+      "language": "en",
+      "goal": "Practice handling a patient who is downplaying their pain.",
+      "script": [
+        { "speaker": "character", "line": "I'm fine, doc. Just a little tweak." },
+        { "speaker": "participant", "line": "Describe the pain for me." },
+        { "speaker": "character", "line": "(Sighs) Okay, it's more of a sharp pain. A 6 or 7 maybe." },
+        { "speaker": "llm", "action": "stop" }
+      ]
+    }
+  ]
+}

--- a/src/resources/scripts/scripts_zh-TW.json
+++ b/src/resources/scripts/scripts_zh-TW.json
@@ -1,0 +1,20 @@
+{
+  "resource_version": "1.0",
+  "last_modified": "2025-07-29T01:37:13Z",
+  "modified_by": "manual",
+  "scripts": [
+    {
+      "id": "medical_acute_frustration_simple_zh_tw",
+      "scenario_id": "medical_interview_zh_tw",
+      "character_id": "patient_acute_zh_tw",
+      "language": "zh-TW",
+      "goal": "練習處理病患輕描淡寫疼痛的情況。",
+      "script": [
+        { "speaker": "character", "line": "醫生，我沒事啦，只是小扭傷而已。" },
+        { "speaker": "participant", "line": "請形容一下你的疼痛。" },
+        { "speaker": "character", "line": "（嘆氣）好吧，是比較尖銳的痛，大概六、七分吧。" },
+        { "speaker": "llm", "action": "stop" }
+      ]
+    }
+  ]
+}

--- a/test/python/unit/common/test_resource_loader.py
+++ b/test/python/unit/common/test_resource_loader.py
@@ -303,6 +303,32 @@ async def test_get_character_by_id_found(mock_storage):
     assert character["name"] == "The Villain"
 
 
+@pytest.mark.asyncio
+async def test_get_scripts_success(mock_storage):
+    """Test loading scripts list."""
+    mock_storage.list_keys.return_value = ["resources/scripts/scripts.json"]
+    mock_storage.read.return_value = '{"scripts": [{"id": "s1"}]}'
+
+    loader = ResourceLoader(mock_storage)
+    scripts = await loader.get_scripts()
+
+    assert len(scripts) == 1
+    assert scripts[0]["id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_get_script_by_id_found(mock_storage):
+    """Test finding an existing script by ID."""
+    mock_storage.list_keys.return_value = ["resources/scripts/scripts.json"]
+    mock_storage.read.return_value = '{"scripts": [{"id": "demo"}]}'
+
+    loader = ResourceLoader(mock_storage)
+    script = await loader.get_script_by_id("demo")
+
+    assert script is not None
+    assert script["id"] == "demo"
+
+
 # Resource Path Discovery Tests
 @pytest.mark.asyncio
 async def test_custom_base_prefix(mock_storage):

--- a/test/python/unit/scripts/test_validate_resources.py
+++ b/test/python/unit/scripts/test_validate_resources.py
@@ -132,6 +132,37 @@ class TestResourceValidator:
         assert resource_validator.validate() is False
         assert "language 'en' but file suggests 'zh-TW'" in resource_validator.errors[0]
 
+    def test_validate_script_cross_reference_failure(self, resource_validator):
+        """Test validation fails when a script references missing scenario or character."""
+        create_resource_file(
+            Path(resource_validator.resources_dir) / "characters.json",
+            {
+                "resource_version": "1.0",
+                "last_modified": "2025-01-01T00:00:00Z",
+                "characters": [{"id": "char1", "name": "Char 1", "description": "", "language": "en", "system_prompt": ""}]
+            }
+        )
+        create_resource_file(
+            Path(resource_validator.resources_dir) / "scenarios.json",
+            {
+                "resource_version": "1.0",
+                "last_modified": "2025-01-01T00:00:00Z",
+                "scenarios": [{"id": "sc1", "name": "Scene", "description": "", "language": "en", "compatible_characters": ["char1"]}]
+            }
+        )
+        create_resource_file(
+            Path(resource_validator.resources_dir) / "scripts.json",
+            {
+                "resource_version": "1.0",
+                "last_modified": "2025-01-01T00:00:00Z",
+                "scripts": [
+                    {"id": "scr1", "scenario_id": "sc_missing", "character_id": "char1", "language": "en", "script": []}
+                ]
+            }
+        )
+        assert resource_validator.validate() is False
+        assert "references non-existent scenario" in resource_validator.errors[0]
+
     def test_validate_successful_run(self, resource_validator):
         """Test a successful validation run."""
         create_resource_file(
@@ -150,6 +181,17 @@ class TestResourceValidator:
                 "scenarios": [{
                     "id": "scen1", "name": "Scene 1", "description": "", "language": "en",
                     "compatible_characters": ["char1"]
+                }]
+            }
+        )
+        create_resource_file(
+            Path(resource_validator.resources_dir) / "scripts.json",
+            {
+                "resource_version": "1.0",
+                "last_modified": "2025-01-01T00:00:00Z",
+                "scripts": [{
+                    "id": "script1", "scenario_id": "scen1", "character_id": "char1",
+                    "language": "en", "script": []
                 }]
             }
         )


### PR DESCRIPTION
## Summary
- add new script JSON resources in English and Traditional Chinese
- support scripts in `ResourceLoader`
- allow `ChatHandler` to use optional scripts
- extend resource validation to include scripts and cross references
- update unit tests for new script features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889684e4c5c8329b7df28f1e7834ecf