### PR TITLE
feat(voice): adopt WebSocket best practices for bi-directional audio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Backend (Python): `src/python/role_play/*` (API, chat, voice, evaluation, common). Entry point: `src/python/run_server.py`.
+- Frontend (Vue + TS): `src/ts/role_play/ui` (Vite app: `src`, `components`, `composables`, `services`).
+- Tests: `test/python/{unit,integration}` with shared fixtures in `test/python/fixtures`.
+- Config: environment YAMLs in `config/{dev,beta,prod}.yaml` (env vars can override). Data/resources in `data/`.
+- Tooling: `Makefile` (build/test/deploy), `Dockerfile`, `pytest.ini`, `.env(.example)`.
+
+## Build, Test, and Development Commands
+- Backend setup: `python -m venv venv && source venv/bin/activate && pip install -r src/python/requirements-dev.txt`.
+- Run API locally: `source venv/bin/activate && python src/python/run_server.py` (ensure `STORAGE_PATH` exists; defaults to `./data`).
+- Frontend dev: `cd src/ts/role_play/ui && npm i && npm run dev` (Vite at http://localhost:5173).
+- Test suite: `make test` (pytest with coverage) or `pytest -q` (see markers below).
+- Docker (local): `make run-local-docker DATA_DIR=./data` (serves on http://localhost:8080).
+- Build/Deploy: `make build-docker`, `make push-docker`, `make deploy ENV=dev` (requires GCP config; see `ENVIRONMENTS.md`).
+
+## Coding Style & Naming Conventions
+- Python: format with Black; imports via isort; prefer type hints. Naming: `snake_case` (functions/modules), `PascalCase` (classes), `UPPER_SNAKE` (constants).
+- TypeScript/Vue: `PascalCase` for components (`*.vue`), `camelCase` for composables/services (e.g., `useChatData.ts`). Two-space indent.
+- Keep modules under existing namespaces (do not create parallel roots).
+
+## Testing Guidelines
+- Framework: pytest. Coverage target: 25%+ (HTML at `test/python/htmlcov/index.html`).
+- Discovery: files `test_*.py`; classes `Test*`; functions `test_*`.
+- Markers: `unit`, `integration`, `e2e`, `slow`, `auth`, `storage`, `cloud`. Example: `pytest -m unit`.
+
+## Commit & Pull Request Guidelines
+- Style: Conventional Commits when possible (e.g., `feat: ...`, `fix(deps): ...`).
+- Commits: small, descriptive, present tense; reference issues (e.g., `#42`).
+- PRs: include summary, rationale, test plan, and screenshots for UI changes. Link issues and note any config/devops changes.
+- CI: ensure `make test` passes locally before requesting review.
+
+## Security & Configuration Tips
+- Never commit secrets. Use `.env` for local dev; production secrets live in GCP Secret Manager.
+- Adjust runtime via `config/*.yaml` and env vars (`PORT`, `STORAGE_PATH`, `CORS_ALLOWED_ORIGINS`, etc.). See `ENVIRONMENTS.md` and `STORAGE_CONFIG.md`.
+
+## Agent-Specific Instructions (Claude/Gemini)
+- Architecture: layered modules; handlers are stateless and created per request/connection. Register handlers via YAML in `config/*.yaml`.
+- Dependency Injection: use FastAPI `Depends()`; cache singletons with `functools.lru_cache` (e.g., ContentLoader, ChatLogger). Avoid mutable state on handler instances.
+- Storage & Locking: abstract through `StorageBackend` (file/GCS/S3). Use key paths without extensions (e.g., `users/{user_id}/profile`). Separate lock lease duration from acquisition timeout; wrap blocking I/O with `asyncio.to_thread`.
+- Chat System: persist messages as JSONL under `users/{user_id}/chat_logs/{session_id}`; create a fresh ADK runner per message; drive prompts by user language. See `/GEMINI.md` and root `/CLAUDE.md` for ADK notes.
+- Evaluation Reports: store at `users/{user_id}/eval_reports/{session_id}/{timestamp_uuid}` with metadata; expose GET latest/all and POST re-evaluate endpoints.
+- Frontend Patterns: domain-based Vue structure, composables for async ops and confirmations, sync TS types with Pydantic models, inject JWT via `Authorization: Bearer <token>`; i18n supports `en` and `zh-TW`.
+- Testing: prefer fast unit tests; mark `integration`, `e2e`, `slow`, `cloud` selectively. Use `make test-chat` for chat-only coverage.
+
+For deeper guidance, refer to: `GEMINI.md` (model/runtime, storage/locking overview), `CLAUDE.md` (repo-wide workflows), `src/python/CLAUDE.md` (Python DI/stateless patterns), `src/ts/CLAUDE.md` (frontend patterns), and `test/CLAUDE.md` (test layout and conventions).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,39 @@ make test-specific TEST_PATH="test/python/unit/chat/test_chat_logger.py"
 - [x] **Internationalization**: Full English/Traditional Chinese support for new UI elements
 - [x] **CSS Improvements**: Fixed radio button alignment issues with proper flexbox layout
 
+### Voice Chat with Intelligent Transcript Management (Completed)
+- [x] **Three-Tier Transcript System**: Implemented sophisticated buffering to prevent fragmented logs
+  - **Live Display Buffer**: Real-time partial transcript updates for immediate user feedback
+  - **Stabilization Buffer**: Quality filtering using stability thresholds and sentence boundary detection
+  - **Persistent Log**: Only finalized, coherent utterances saved to ChatLogger with voice metadata
+- [x] **Backend Voice Module** (`src/python/role_play/voice/`):
+  - **TranscriptBuffer**: Intelligent partial→final transitions with configurable quality controls
+  - **SessionTranscriptManager**: Dual-buffer management for user/assistant speech separation
+  - **ADKVoiceService**: Native ADK `run_live()` integration with `LiveRequestQueue` for bidirectional streaming
+  - **VoiceChatHandler**: WebSocket endpoint (`/api/voice/ws/{session_id}`) with JWT authentication
+  - **Voice Models**: Complete data models for audio chunks, transcripts, and session management
+- [x] **Extended ChatLogger Integration**: New voice logging methods preserve existing JSONL format
+  - `log_voice_message()`: Stores transcripts with duration, confidence, and voice metadata
+  - `log_voice_session_start/end()`: Session lifecycle tracking with statistics
+  - Voice events logged alongside text messages for unified conversation history
+- [x] **Frontend Voice Components** (`src/ts/role_play/ui/src/`):
+  - **VoiceTranscript.vue**: Intelligent UI with real-time partial updates and stability indicators
+  - **useTranscriptBuffer.ts**: Frontend buffering logic mirroring backend quality control
+  - **useVoiceWebSocket.ts**: Modern AudioWorkletNode integration with robust connection management
+  - **Voice Types**: Complete TypeScript definitions for voice communication
+- [x] **Configuration & Quality Control**:
+  - Configurable transcript parameters: stability threshold (0.8), finalization timeout (2s), min utterance length
+  - Smart sentence boundary detection and timeout-based finalization
+  - Mock mode for development without API keys
+  - Voice handler registered in server configuration
+- [x] **Internationalization**: Full bilingual support (English/Traditional Chinese) for voice UI
+- [x] **Comprehensive Testing**: Unit tests for transcript buffering logic and WebSocket handler integration
+- [x] **Key Innovations**:
+  - **Prevents Fragmented Logs**: No more "I", "I want", "I want to" entries - only complete utterances
+  - **Real-time UX**: Live partial feedback while maintaining log quality
+  - **ADK Native**: Uses `run_live()` instead of direct Gemini API for better integration
+  - **Character Consistency**: Reuses existing agent system for voice responses
+
 ### Pending Development
 - [ ] **Resource Architecture for Script Creator**:
   - [x] Design LayeredResourceLoader for base + user resources (see RESOURCE_ARCHITECTURE.md)
@@ -197,7 +230,6 @@ make test-specific TEST_PATH="test/python/unit/chat/test_chat_logger.py"
   - [ ] Create utility functions for date formatting across components
   - [ ] Add validation that session belongs to requesting user before creating evaluation reports
   - [ ] Add retry logic for transient storage failures in evaluation system
-- [ ] WebSocket: `server/websocket.py` connection manager
 - [ ] Auth Module: Complete OAuth implementation
 - [ ] Scripter: Complete module implementation  
 - [ ] Frontend: Modular monolith restructure, chat/eval interfaces
@@ -279,6 +311,7 @@ make test-specific TEST_PATH="test/python/unit/chat/test_chat_logger.py"
 ### Architecture Highlights
 - **Storage**: Async distributed locking, lease (60-300s) vs timeout (5-30s) separation
 - **Chat**: Separated ADK runtime from JSONL persistence, per-message Runner creation, utility methods for JSONL parsing, centralized agent configuration
+- **Voice**: Three-tier transcript management (partial/stabilization/final), ADK `run_live()` integration, intelligent buffering prevents fragmented logs
 - **Backend Structure**: Helper methods for session validation, message logging, content loading, response generation
 - **Frontend Patterns**: Composable architecture for modal management, async operations, data loading, dual-flow session creation with script/character selection
 - **Config**: YAML + env vars, dynamic handler loading, fail-fast validation

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -59,6 +59,7 @@ enabled_handlers:
   user_account: "role_play.server.user_account_handler.UserAccountHandler"
   chat: "role_play.chat.handler.ChatHandler"
   evaluation: "role_play.evaluation.handler.EvaluationHandler"
+  voice: "role_play.voice.handler.VoiceChatHandler"
   # Add more handlers as they're implemented:
   # scripter: "role_play.scripter.handler.ScripterHandler"
 
@@ -71,3 +72,29 @@ supported_languages:
 # Resource configuration
 resources:
   base_prefix: "resources/"
+
+# Voice chat configuration
+voice:
+  # Transcript buffering settings
+  transcript:
+    stability_threshold: "${VOICE_STABILITY_THRESHOLD:0.8}"
+    finalization_timeout_ms: "${VOICE_FINALIZATION_TIMEOUT:2000}"
+    min_utterance_length: "${VOICE_MIN_UTTERANCE_LENGTH:3}"
+    sentence_boundary_patterns:
+      - "[.!?]+\\s*$"
+      - "\\n+"
+  
+  # Audio processing settings
+  audio:
+    default_format: "pcm"
+    default_sample_rate: 16000
+    default_channels: 1
+    default_bit_depth: 16
+    chunk_size_ms: "${VOICE_CHUNK_SIZE_MS:100}"
+    
+  # Voice model settings
+  model:
+    default_voice: "Aoede"
+    gemini_api_key: "${GEMINI_API_KEY:}"
+    # Mock mode when no API key is available
+    enable_mock: "${VOICE_ENABLE_MOCK:true}"

--- a/src/python/role_play/common/resource_loader.py
+++ b/src/python/role_play/common/resource_loader.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Any, Dict, List
 
-from role_play.common.storage import StorageBackend
+from .storage import StorageBackend
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/role_play/voice/__init__.py
+++ b/src/python/role_play/voice/__init__.py
@@ -1,0 +1,51 @@
+"""Voice chat module for real-time bidirectional audio communication."""
+
+from .handler import VoiceChatHandler
+from .adk_voice_service import ADKVoiceService, VoiceSession
+from .transcript_manager import (
+    TranscriptBuffer,
+    TranscriptSegment,
+    BufferedTranscript,
+    SessionTranscriptManager
+)
+from .models import (
+    VoiceClientRequest,
+    VoiceConfigMessage,
+    VoiceStatusMessage,
+    VoiceErrorMessage,
+    TranscriptPartialMessage,
+    TranscriptFinalMessage,
+    AudioChunkMessage,
+    TurnStatusMessage,
+    VoiceSessionInfo,
+    VoiceSessionStats,
+    VoiceTranscriptConfig
+)
+
+__all__ = [
+    # Handler
+    "VoiceChatHandler",
+    
+    # Core services
+    "ADKVoiceService",
+    "VoiceSession",
+    
+    # Transcript management
+    "TranscriptBuffer",
+    "TranscriptSegment", 
+    "BufferedTranscript",
+    "SessionTranscriptManager",
+    
+    # Models
+    "VoiceClientRequest",
+    "VoiceConfigMessage",
+    "VoiceStatusMessage",
+    "VoiceErrorMessage",
+    "TranscriptPartialMessage",
+    "TranscriptFinalMessage",
+    "AudioChunkMessage",
+    "TurnStatusMessage",
+    "VoiceSessionInfo",
+    "VoiceSessionStats",
+    "VoiceTranscriptConfig",
+]

--- a/src/python/role_play/voice/adk_voice_service.py
+++ b/src/python/role_play/voice/adk_voice_service.py
@@ -392,6 +392,21 @@ class VoiceSession:
             **session_stats
         }
         
+        # Attempt to gracefully close runner/live events
+        try:
+            if hasattr(self.live_events, "aclose") and callable(self.live_events.aclose):
+                await self.live_events.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing live_events for session {self.session_id}: {e}")
+
+        try:
+            if hasattr(self.runner, "close") and callable(self.runner.close):
+                maybe_coro = self.runner.close()
+                if asyncio.iscoroutine(maybe_coro):
+                    await maybe_coro
+        except Exception as e:
+            logger.warning(f"Error closing runner for session {self.session_id}: {e}")
+
         logger.info(f"Voice session {self.session_id} cleanup completed: {final_stats}")
         return final_stats
 

--- a/src/python/role_play/voice/adk_voice_service.py
+++ b/src/python/role_play/voice/adk_voice_service.py
@@ -1,0 +1,403 @@
+"""ADK-based voice service for real-time bidirectional audio streaming."""
+
+import asyncio
+import logging
+from typing import AsyncGenerator, Optional, Dict, Any, Tuple, List
+from google.adk.runners import Runner
+from google.adk.agents import LiveRequestQueue
+from google.adk.agents.run_config import RunConfig
+from google.adk.sessions import InMemorySessionService
+from google.genai.types import (
+    Content, Part, Blob, 
+    AudioTranscriptionConfig,
+    AudioChunk
+)
+
+from ..dev_agents.roleplay_agent.agent import get_production_agent
+from ..chat.chat_logger import ChatLogger
+from ..common.time_utils import utc_now_isoformat
+from .transcript_manager import (
+    SessionTranscriptManager, 
+    TranscriptSegment, 
+    BufferedTranscript
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ADKVoiceService:
+    """
+    Manages ADK live streaming sessions for voice chat.
+    
+    This service creates and manages real-time voice interactions using
+    ADK's run_live() method with intelligent transcript buffering.
+    """
+    
+    def __init__(self):
+        self.active_sessions: Dict[str, 'VoiceSession'] = {}
+
+    async def create_voice_session(
+        self,
+        session_id: str,
+        user_id: str,
+        character_id: str,
+        scenario_id: str,
+        language: str = "en",
+        script_data: Optional[Dict] = None,
+        adk_session_service: Optional[InMemorySessionService] = None,
+        transcript_config: Optional[Dict] = None
+    ) -> 'VoiceSession':
+        """
+        Create and start an ADK live voice session.
+        
+        Args:
+            session_id: Unique session identifier
+            user_id: User ID for session ownership
+            character_id: Character to roleplay
+            scenario_id: Scenario context
+            language: Language for responses (en, zh-TW, ja)
+            script_data: Optional script data for guided conversations
+            adk_session_service: ADK session service instance
+            transcript_config: Configuration for transcript buffering
+            
+        Returns:
+            VoiceSession: Active voice session instance
+        """
+        logger.info(f"Creating voice session {session_id} for user {user_id}")
+        
+        # Get production agent with character/scenario context
+        agent = await get_production_agent(
+            character_id=character_id,
+            scenario_id=scenario_id,
+            language=language,
+            scripted=bool(script_data)
+        )
+        
+        if not agent:
+            raise ValueError(f"Could not create agent for character {character_id}, scenario {scenario_id}")
+
+        # Create ADK runner
+        runner = Runner(app_name="roleplay_voice", agent=agent)
+        
+        # Get or create ADK session
+        if adk_session_service:
+            adk_session = await adk_session_service.get_session(
+                app_name="roleplay_voice", 
+                user_id=user_id, 
+                session_id=session_id
+            )
+            
+            if not adk_session:
+                # Create new ADK session
+                initial_state = {
+                    "character_id": character_id,
+                    "scenario_id": scenario_id,
+                    "script_data": script_data,
+                    "language": language,
+                    "voice_session": True,
+                    "session_creation_time_iso": utc_now_isoformat()
+                }
+                
+                adk_session = await adk_session_service.create_session(
+                    app_name="roleplay_voice",
+                    user_id=user_id,
+                    session_id=session_id,
+                    state=initial_state
+                )
+        else:
+            adk_session = None
+
+        # Configure for audio response and transcription
+        run_config = RunConfig(
+            response_modalities=["AUDIO"],
+            output_audio_transcription=AudioTranscriptionConfig(),
+            input_audio_transcription=AudioTranscriptionConfig()
+        )
+
+        # Create live request queue for bidirectional streaming
+        live_request_queue = LiveRequestQueue()
+        
+        # Start live streaming
+        live_events = runner.run_live(
+            session=adk_session,
+            live_request_queue=live_request_queue,
+            run_config=run_config
+        )
+
+        # Create transcript manager
+        transcript_manager = SessionTranscriptManager(**(transcript_config or {}))
+
+        # Create voice session wrapper
+        voice_session = VoiceSession(
+            session_id=session_id,
+            user_id=user_id,
+            runner=runner,
+            live_events=live_events,
+            live_request_queue=live_request_queue,
+            transcript_manager=transcript_manager,
+            adk_session=adk_session
+        )
+        
+        # Store session
+        self.active_sessions[session_id] = voice_session
+        
+        logger.info(f"Voice session {session_id} created successfully")
+        return voice_session
+
+    async def get_session(self, session_id: str) -> Optional['VoiceSession']:
+        """Get active voice session by ID."""
+        return self.active_sessions.get(session_id)
+
+    async def end_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """End voice session and return session statistics."""
+        voice_session = self.active_sessions.pop(session_id, None)
+        if not voice_session:
+            return None
+            
+        return await voice_session.cleanup()
+
+
+class VoiceSession:
+    """
+    Represents an active voice session with ADK live streaming.
+    
+    Manages the lifecycle of a voice conversation including audio streaming,
+    transcript management, and cleanup.
+    """
+    
+    def __init__(
+        self,
+        session_id: str,
+        user_id: str,
+        runner: Runner,
+        live_events: AsyncGenerator,
+        live_request_queue: LiveRequestQueue,
+        transcript_manager: SessionTranscriptManager,
+        adk_session: Optional[Any] = None
+    ):
+        self.session_id = session_id
+        self.user_id = user_id
+        self.runner = runner
+        self.live_events = live_events
+        self.live_request_queue = live_request_queue
+        self.transcript_manager = transcript_manager
+        self.adk_session = adk_session
+        
+        # Session state
+        self.active = True
+        self.event_handlers: Dict[str, callable] = {}
+        
+        # Statistics
+        self.stats = {
+            "started_at": utc_now_isoformat(),
+            "audio_chunks_sent": 0,
+            "audio_chunks_received": 0,
+            "transcripts_processed": 0,
+            "errors": 0
+        }
+
+    async def send_audio(self, audio_data: bytes, mime_type: str = "audio/pcm") -> None:
+        """Send audio data to the live session."""
+        try:
+            blob = Blob(mime_type=mime_type, data=audio_data)
+            await self.live_request_queue.send_realtime(blob)
+            self.stats["audio_chunks_sent"] += 1
+            
+        except Exception as e:
+            logger.error(f"Error sending audio in session {self.session_id}: {e}")
+            self.stats["errors"] += 1
+            raise
+
+    async def send_text(self, text: str) -> None:
+        """Send text input to the live session."""
+        try:
+            content = Content(parts=[Part(text=text)])
+            await self.live_request_queue.send_content(content)
+            
+            # Create transcript segment for immediate display
+            segment = TranscriptSegment(
+                text=text,
+                stability=1.0,
+                is_final=True,
+                timestamp=utc_now_isoformat(),
+                confidence=1.0,
+                role="user"
+            )
+            
+            await self.transcript_manager.add_user_segment(segment)
+            
+        except Exception as e:
+            logger.error(f"Error sending text in session {self.session_id}: {e}")
+            self.stats["errors"] += 1
+            raise
+
+    async def process_events(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Process live events from ADK and yield processed events.
+        
+        Yields events like:
+        - audio_chunk: Audio data from assistant
+        - transcript_partial: Partial transcript for display
+        - transcript_final: Final transcript for logging
+        - turn_status: Turn completion/interruption status
+        """
+        try:
+            async for event in self.live_events:
+                if not self.active:
+                    break
+                    
+                yield await self._process_single_event(event)
+                
+        except asyncio.CancelledError:
+            logger.info(f"Voice session {self.session_id} event processing cancelled")
+        except Exception as e:
+            logger.error(f"Error processing events in session {self.session_id}: {e}")
+            self.stats["errors"] += 1
+            yield {
+                "type": "error",
+                "error": str(e),
+                "timestamp": utc_now_isoformat()
+            }
+
+    async def _process_single_event(self, event) -> Dict[str, Any]:
+        """Process a single ADK live event."""
+        self.stats["transcripts_processed"] += 1
+        
+        # Turn status events
+        if hasattr(event, 'turn_complete') or hasattr(event, 'interrupted'):
+            return {
+                "type": "turn_status",
+                "turn_complete": getattr(event, 'turn_complete', False),
+                "interrupted": getattr(event, 'interrupted', False),
+                "timestamp": utc_now_isoformat()
+            }
+
+        # Input transcription (user speech)
+        if hasattr(event, 'input_transcription') and event.input_transcription:
+            transcription = event.input_transcription
+            
+            segment = TranscriptSegment(
+                text=transcription.text,
+                stability=getattr(transcription, 'stability', 1.0),
+                is_final=getattr(transcription, 'is_final', True),
+                timestamp=utc_now_isoformat(),
+                confidence=getattr(transcription, 'confidence', None),
+                role="user"
+            )
+            
+            display_text, finalized = await self.transcript_manager.add_user_segment(segment)
+            
+            if finalized:
+                return {
+                    "type": "transcript_final",
+                    "text": finalized.text,
+                    "role": "user",
+                    "duration_ms": finalized.duration_ms,
+                    "confidence": finalized.confidence,
+                    "metadata": finalized.voice_metadata,
+                    "timestamp": finalized.timestamp
+                }
+            else:
+                return {
+                    "type": "transcript_partial",
+                    "text": display_text or "",
+                    "role": "user",
+                    "stability": segment.stability,
+                    "timestamp": segment.timestamp
+                }
+
+        # Output transcription (assistant speech)
+        if hasattr(event, 'output_transcription') and event.output_transcription:
+            transcription = event.output_transcription
+            
+            segment = TranscriptSegment(
+                text=transcription.text,
+                stability=getattr(transcription, 'stability', 1.0),
+                is_final=getattr(transcription, 'is_final', True),
+                timestamp=utc_now_isoformat(),
+                confidence=getattr(transcription, 'confidence', None),
+                role="assistant"
+            )
+            
+            display_text, finalized = await self.transcript_manager.add_assistant_segment(segment)
+            
+            if finalized:
+                return {
+                    "type": "transcript_final",
+                    "text": finalized.text,
+                    "role": "assistant",
+                    "duration_ms": finalized.duration_ms,
+                    "confidence": finalized.confidence,
+                    "metadata": finalized.voice_metadata,
+                    "timestamp": finalized.timestamp
+                }
+            else:
+                return {
+                    "type": "transcript_partial",
+                    "text": display_text or "",
+                    "role": "assistant",
+                    "stability": segment.stability,
+                    "timestamp": segment.timestamp
+                }
+
+        # Audio content (assistant response)
+        if hasattr(event, 'content') and event.content:
+            content = event.content
+            if content.parts:
+                for part in content.parts:
+                    if hasattr(part, 'inline_data') and part.inline_data:
+                        self.stats["audio_chunks_received"] += 1
+                        return {
+                            "type": "audio_chunk",
+                            "data": part.inline_data.data,
+                            "mime_type": part.inline_data.mime_type,
+                            "timestamp": utc_now_isoformat()
+                        }
+
+        # Default: unknown event
+        return {
+            "type": "unknown",
+            "event_type": type(event).__name__,
+            "timestamp": utc_now_isoformat()
+        }
+
+    async def end_session(self) -> None:
+        """End the voice session gracefully."""
+        logger.info(f"Ending voice session {self.session_id}")
+        self.active = False
+        
+        # Close the live request queue
+        if self.live_request_queue:
+            self.live_request_queue.close()
+
+    async def flush_transcripts(self) -> List[BufferedTranscript]:
+        """Flush all pending transcripts."""
+        return await self.transcript_manager.flush_all()
+
+    async def cleanup(self) -> Dict[str, Any]:
+        """Cleanup session and return final statistics."""
+        if self.active:
+            await self.end_session()
+        
+        # Flush any remaining transcripts
+        pending_transcripts = await self.flush_transcripts()
+        
+        # Get session statistics
+        session_stats = self.transcript_manager.get_session_stats()
+        
+        final_stats = {
+            **self.stats,
+            "ended_at": utc_now_isoformat(),
+            "pending_transcripts_flushed": len(pending_transcripts),
+            **session_stats
+        }
+        
+        logger.info(f"Voice session {self.session_id} cleanup completed: {final_stats}")
+        return final_stats
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get current session statistics."""
+        return {
+            **self.stats,
+            **self.transcript_manager.get_session_stats()
+        }

--- a/src/python/role_play/voice/handler.py
+++ b/src/python/role_play/voice/handler.py
@@ -113,7 +113,13 @@ class VoiceChatHandler(BaseHandler):
         try:
             logger.info(f"Voice WebSocket connection attempt for session {session_id}")
             
-            # 1. Validate JWT token
+            # 1. Check for missing token
+            if not token:
+                logger.error(f"Missing token for session {session_id}")
+                await websocket.close(code=1008, reason="Missing token parameter")
+                return
+            
+            # 2. Validate JWT token
             user = await self._validate_jwt_token(token)
             if not user:
                 logger.error(f"JWT validation failed for session {session_id}")

--- a/src/python/role_play/voice/handler.py
+++ b/src/python/role_play/voice/handler.py
@@ -1,0 +1,453 @@
+"""Voice chat handler for real-time voice interactions with intelligent transcript management."""
+
+import asyncio
+import logging
+import base64
+import json
+import os
+from typing import Optional, Dict, Any
+from fastapi import WebSocket, WebSocketDisconnect, Query, HTTPException, APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from ..server.base_handler import BaseHandler
+from ..server.dependencies import (
+    get_chat_logger,
+    get_adk_session_service,
+    get_resource_loader,
+    get_storage_backend,
+    get_auth_manager,
+)
+from ..common.models import User
+from ..common.time_utils import utc_now_isoformat
+from ..common.storage import StorageBackend
+from ..chat.chat_logger import ChatLogger
+from ..common.resource_loader import ResourceLoader
+from google.adk.sessions import InMemorySessionService
+
+from .models import (
+    VoiceClientRequest,
+    VoiceSessionInfo,
+    TranscriptPartialMessage,
+    TranscriptFinalMessage,
+    VoiceConfigMessage,
+    VoiceStatusMessage,
+    VoiceErrorMessage,
+    AudioChunkMessage,
+    TurnStatusMessage,
+    VoiceSessionResponse,
+    VoiceTranscriptConfig,
+    VoiceSessionStats
+)
+from .adk_voice_service import ADKVoiceService
+from .transcript_manager import TranscriptSegment
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceChatHandler(BaseHandler):
+    """Handler for voice chat WebSocket connections with intelligent transcript management."""
+
+    def __init__(self):
+        super().__init__()
+        self.voice_service = ADKVoiceService()
+
+    @property
+    def router(self) -> APIRouter:
+        if self._router is None:
+            self._router = APIRouter()
+            
+            # WebSocket endpoint for voice chat
+            @self._router.websocket("/ws/{session_id}")
+            async def voice_websocket_endpoint(
+                websocket: WebSocket,
+                session_id: str,
+            ):
+                # Accept the WebSocket connection first
+                await websocket.accept()
+                
+                # Extract token from query parameters
+                token = websocket.query_params.get("token")
+                if not token:
+                    await websocket.close(code=1008, reason="Missing token parameter")
+                    return
+                
+                await self.handle_voice_session(websocket, session_id, token)
+            
+            # REST endpoints for voice session management
+            @self._router.get("/session/{session_id}/info")
+            async def get_voice_session_info(
+                session_id: str,
+                token: str = Query(..., description="JWT authentication token"),
+            ) -> VoiceSessionResponse:
+                return await self.get_session_info(session_id, token)
+            
+            @self._router.get("/session/{session_id}/stats")
+            async def get_voice_session_stats(
+                session_id: str,
+                token: str = Query(..., description="JWT authentication token"),
+            ) -> VoiceSessionResponse:
+                return await self.get_session_stats(session_id, token)
+            
+            # Simple test endpoint
+            @self._router.get("/test")
+            async def voice_test():
+                return {"message": "Voice handler is working", "status": "ok"}
+        
+        return self._router
+
+    @property
+    def prefix(self) -> str:
+        return "/voice"
+
+    async def handle_voice_session(
+        self,
+        websocket: WebSocket,
+        session_id: str,
+        token: str,
+    ):
+        """Handle a voice chat WebSocket connection with intelligent transcript management."""
+        user = None
+        voice_session = None
+        message_counter = 0
+        
+        try:
+            logger.info(f"Voice WebSocket connection attempt for session {session_id}")
+            
+            # 1. Validate JWT token
+            user = await self._validate_jwt_token(token)
+            if not user:
+                logger.error(f"JWT validation failed for session {session_id}")
+                await websocket.close(code=1008, reason="Invalid authentication token")
+                return
+            
+            logger.info(f"JWT validation successful for user {user.username}")
+            
+            # Get dependencies
+            storage = get_storage_backend()
+            chat_logger = get_chat_logger(storage)
+            adk_session_service = get_adk_session_service()
+            resource_loader = get_resource_loader()
+            
+            # 2. Validate session exists and belongs to user
+            adk_session = await self._validate_session(
+                session_id, user.id, adk_session_service, chat_logger
+            )
+            if not adk_session:
+                await websocket.close(code=1008, reason="Session not found or access denied")
+                return
+            
+            logger.info(f"Voice WebSocket connected for session {session_id}, user {user.id}")
+            
+            # Send initial status
+            await websocket.send_json(
+                VoiceStatusMessage(status="connecting", message="Initializing voice session").dict()
+            )
+            
+            # 3. Create voice session with transcript configuration
+            transcript_config = VoiceTranscriptConfig().dict()
+            
+            voice_session = await self.voice_service.create_voice_session(
+                session_id=session_id,
+                user_id=user.id,
+                character_id=adk_session.state.get("character_id"),
+                scenario_id=adk_session.state.get("scenario_id"),
+                language=getattr(user, 'preferred_language', 'en'),
+                script_data=adk_session.state.get("script_data"),
+                adk_session_service=adk_session_service,
+                transcript_config=transcript_config
+            )
+            
+            # 4. Send voice configuration to client
+            voice_config = VoiceConfigMessage(
+                audio_format="pcm",
+                sample_rate=16000,
+                channels=1,
+                bit_depth=16,
+                language=getattr(user, 'preferred_language', 'en'),
+                voice_name="Aoede"  # Default voice, could be character-specific
+            )
+            await websocket.send_json(voice_config.dict())
+            
+            # 5. Log voice session start
+            await chat_logger.log_voice_session_start(
+                user_id=user.id,
+                session_id=session_id,
+                voice_config=voice_config.dict()
+            )
+            
+            # Send ready status
+            await websocket.send_json(
+                VoiceStatusMessage(status="ready", message="Voice session ready").dict()
+            )
+            
+            # 6. Start bidirectional streaming
+            await self._handle_bidirectional_streaming(
+                websocket, voice_session, chat_logger, user.id, session_id, message_counter
+            )
+            
+        except WebSocketDisconnect:
+            logger.info(f"WebSocket disconnected for session {session_id}")
+        except Exception as e:
+            logger.error(f"Voice session error for {session_id}: {e}", exc_info=True)
+            try:
+                await websocket.send_json(
+                    VoiceErrorMessage(
+                        error=str(e), 
+                        timestamp=utc_now_isoformat()
+                    ).dict()
+                )
+            except:
+                pass  # Connection might be closed
+        finally:
+            # Cleanup
+            if voice_session:
+                try:
+                    final_stats = await voice_session.cleanup()
+                    
+                    # Log voice session end
+                    if user:
+                        storage = get_storage_backend()
+                        chat_logger = get_chat_logger(storage)
+                        await chat_logger.log_voice_session_end(
+                            user_id=user.id,
+                            session_id=session_id,
+                            voice_stats=final_stats
+                        )
+                        
+                    logger.info(f"Voice session {session_id} cleanup completed")
+                except Exception as cleanup_error:
+                    logger.error(f"Error during voice session cleanup: {cleanup_error}")
+
+    async def _handle_bidirectional_streaming(
+        self,
+        websocket: WebSocket,
+        voice_session,
+        chat_logger: ChatLogger,
+        user_id: str,
+        session_id: str,
+        message_counter: int
+    ):
+        """Handle bidirectional audio streaming with transcript management."""
+        
+        # Create tasks for concurrent streaming
+        receive_task = asyncio.create_task(
+            self._receive_from_client(websocket, voice_session)
+        )
+        
+        send_task = asyncio.create_task(
+            self._send_to_client(websocket, voice_session, chat_logger, user_id, session_id, message_counter)
+        )
+        
+        try:
+            # Wait for either task to complete (usually due to disconnection)
+            done, pending = await asyncio.wait(
+                [receive_task, send_task],
+                return_when=asyncio.FIRST_COMPLETED
+            )
+            
+            # Cancel remaining tasks
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                    
+        except Exception as e:
+            logger.error(f"Error in bidirectional streaming: {e}")
+            raise
+
+    async def _receive_from_client(self, websocket: WebSocket, voice_session):
+        """Receive audio/text from client and forward to voice session."""
+        try:
+            while voice_session.active:
+                # Receive data from WebSocket
+                data = await websocket.receive_text()
+                request = VoiceClientRequest.model_validate_json(data)
+
+                if request.end_session:
+                    logger.info(f"Client requested end of voice session {voice_session.session_id}")
+                    await voice_session.end_session()
+                    break
+
+                # Handle based on MIME type
+                if request.mime_type == "audio/pcm":
+                    # Decode and send audio to voice session
+                    audio_bytes = request.decode_data()
+                    await voice_session.send_audio(audio_bytes, request.mime_type)
+                    
+                elif request.mime_type == "text/plain":
+                    # Send text input
+                    text = request.decode_data()
+                    await voice_session.send_text(text)
+                    
+        except WebSocketDisconnect:
+            logger.info(f"Client disconnected from voice session {voice_session.session_id}")
+            await voice_session.end_session()
+        except Exception as e:
+            logger.error(f"Error receiving from client in session {voice_session.session_id}: {e}")
+            await voice_session.end_session()
+            raise
+
+    async def _send_to_client(
+        self, 
+        websocket: WebSocket, 
+        voice_session, 
+        chat_logger: ChatLogger,
+        user_id: str,
+        session_id: str,
+        message_counter: int
+    ):
+        """Send audio/transcripts to client and manage logging."""
+        try:
+            async for event in voice_session.process_events():
+                if not voice_session.active:
+                    break
+                    
+                event_type = event.get("type")
+                
+                if event_type == "audio_chunk":
+                    # Send audio data to client
+                    audio_msg = AudioChunkMessage(
+                        data=base64.b64encode(event["data"]).decode('utf-8'),
+                        mime_type=event["mime_type"],
+                        timestamp=event["timestamp"]
+                    )
+                    await websocket.send_json(audio_msg.dict())
+                    
+                elif event_type == "transcript_partial":
+                    # Send partial transcript for live display
+                    partial_msg = TranscriptPartialMessage(
+                        text=event["text"],
+                        role=event["role"],
+                        stability=event["stability"],
+                        timestamp=event["timestamp"]
+                    )
+                    await websocket.send_json(partial_msg.dict())
+                    
+                elif event_type == "transcript_final":
+                    # Send final transcript and log to ChatLogger
+                    final_msg = TranscriptFinalMessage(
+                        text=event["text"],
+                        role=event["role"],
+                        duration_ms=event["duration_ms"],
+                        confidence=event["confidence"],
+                        metadata=event["metadata"],
+                        timestamp=event["timestamp"]
+                    )
+                    await websocket.send_json(final_msg.dict())
+                    
+                    # Log finalized transcript to ChatLogger
+                    message_counter += 1
+                    await chat_logger.log_voice_message(
+                        user_id=user_id,
+                        session_id=session_id,
+                        role=event["role"],
+                        transcript_text=event["text"],
+                        duration_ms=event["duration_ms"],
+                        confidence=event["confidence"],
+                        message_number=message_counter,
+                        voice_metadata=event["metadata"]
+                    )
+                    
+                elif event_type == "turn_status":
+                    # Send turn status updates
+                    status_msg = TurnStatusMessage(
+                        turn_complete=event["turn_complete"],
+                        interrupted=event.get("interrupted", False),
+                        timestamp=event["timestamp"]
+                    )
+                    await websocket.send_json(status_msg.dict())
+                    
+                elif event_type == "error":
+                    # Send error message
+                    error_msg = VoiceErrorMessage(
+                        error=event["error"],
+                        timestamp=event["timestamp"]
+                    )
+                    await websocket.send_json(error_msg.dict())
+                    
+        except WebSocketDisconnect:
+            logger.info(f"Client disconnected while sending in session {voice_session.session_id}")
+        except Exception as e:
+            logger.error(f"Error sending to client in session {voice_session.session_id}: {e}")
+            raise
+
+    async def _validate_jwt_token(self, token: str) -> Optional[User]:
+        """Validate JWT token and return user."""
+        try:
+            storage = get_storage_backend()
+            auth_manager = get_auth_manager(storage)
+            token_data = auth_manager.verify_token(token)
+            user = await storage.get_user(token_data.user_id)
+            return user
+        except Exception as e:
+            logger.error(f"JWT validation error: {e}")
+            return None
+
+    async def _validate_session(
+        self, 
+        session_id: str, 
+        user_id: str,
+        adk_session_service: InMemorySessionService,
+        chat_logger: ChatLogger
+    ):
+        """Validate that session exists and belongs to user."""
+        # Check ADK session first
+        adk_session = await adk_session_service.get_session(
+            app_name="roleplay_chat", user_id=user_id, session_id=session_id
+        )
+        
+        if adk_session:
+            return adk_session
+            
+        # If not in ADK memory, check if it's an ended session
+        try:
+            end_info = await chat_logger.get_session_end_info(user_id, session_id)
+            if end_info:
+                logger.warning(f"Attempted to connect to ended session {session_id}")
+                return None
+        except:
+            pass
+            
+        logger.warning(f"Session {session_id} not found for user {user_id}")
+        return None
+
+    async def get_session_info(self, session_id: str, token: str) -> VoiceSessionResponse:
+        """Get voice session information."""
+        user = await self._validate_jwt_token(token)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+            
+        voice_session = await self.voice_service.get_session(session_id)
+        if not voice_session or voice_session.user_id != user.id:
+            raise HTTPException(status_code=404, detail="Voice session not found")
+            
+        session_info = VoiceSessionInfo(
+            session_id=session_id,
+            user_id=user.id,
+            character_id=voice_session.adk_session.state.get("character_id") if voice_session.adk_session else None,
+            scenario_id=voice_session.adk_session.state.get("scenario_id") if voice_session.adk_session else None,
+            language=voice_session.adk_session.state.get("language", "en") if voice_session.adk_session else "en",
+            started_at=voice_session.stats.get("started_at"),
+            transcript_available=True
+        )
+        
+        return VoiceSessionResponse(success=True, session_info=session_info)
+
+    async def get_session_stats(self, session_id: str, token: str) -> VoiceSessionResponse:
+        """Get voice session statistics."""
+        user = await self._validate_jwt_token(token)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+            
+        voice_session = await self.voice_service.get_session(session_id)
+        if not voice_session or voice_session.user_id != user.id:
+            raise HTTPException(status_code=404, detail="Voice session not found")
+            
+        stats = VoiceSessionStats(
+            session_id=session_id,
+            **voice_session.get_stats()
+        )
+        
+        return VoiceSessionResponse(success=True, stats=stats)

--- a/src/python/role_play/voice/models.py
+++ b/src/python/role_play/voice/models.py
@@ -1,0 +1,185 @@
+"""Voice chat models and message types."""
+
+import base64
+from typing import Optional, Dict, Any, List, Union
+from pydantic import BaseModel, Field
+from ..common.models import BaseResponse
+
+
+class VoiceClientRequest(BaseModel):
+    """Request from client containing audio or text data."""
+    mime_type: str = Field(..., description="MIME type of the data (audio/pcm, text/plain)")
+    data: str = Field(..., description="Base64-encoded data")
+    end_session: bool = Field(default=False, description="Whether to end the session")
+    
+    def decode_data(self) -> Union[bytes, str]:
+        """Decode base64 data based on MIME type."""
+        if self.mime_type.startswith("audio/"):
+            return base64.b64decode(self.data)
+        else:
+            return base64.b64decode(self.data).decode('utf-8')
+
+
+class VoiceConfigMessage(BaseModel):
+    """Configuration message sent to client."""
+    type: str = Field(default="config", description="Message type")
+    audio_format: str = Field(..., description="Expected audio format (pcm)")
+    sample_rate: int = Field(default=16000, description="Audio sample rate in Hz")
+    channels: int = Field(default=1, description="Number of audio channels")
+    bit_depth: int = Field(default=16, description="Audio bit depth")
+    language: str = Field(..., description="Response language")
+    voice_name: str = Field(..., description="Character voice name")
+    output_audio_format: str = Field(default="pcm", description="Output audio format")
+
+
+class VoiceStatusMessage(BaseModel):
+    """Status update message."""
+    type: str = Field(default="status", description="Message type")
+    status: str = Field(..., description="Status (connected, ready, error, ended)")
+    message: str = Field(..., description="Status message")
+    timestamp: Optional[str] = None
+
+
+class VoiceErrorMessage(BaseModel):
+    """Error message."""
+    type: str = Field(default="error", description="Message type")
+    error: str = Field(..., description="Error description")
+    code: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+class TranscriptMessage(BaseModel):
+    """Transcript message (partial or final)."""
+    type: str = Field(default="transcript", description="Message type")
+    text: str = Field(..., description="Transcribed text")
+    role: str = Field(..., description="Speaker role (user, assistant)")
+    is_final: bool = Field(default=True, description="Whether this is a final transcript")
+    stability: Optional[float] = Field(None, description="Stability score (0.0-1.0)")
+    confidence: Optional[float] = Field(None, description="Confidence score (0.0-1.0)")
+    timestamp: str = Field(..., description="ISO timestamp")
+
+
+class TranscriptPartialMessage(BaseModel):
+    """Partial transcript for live display."""
+    type: str = Field(default="transcript_partial", description="Message type")
+    text: str = Field(..., description="Partial transcribed text")
+    role: str = Field(..., description="Speaker role (user, assistant)")
+    stability: float = Field(..., description="Stability score (0.0-1.0)")
+    timestamp: str = Field(..., description="ISO timestamp")
+
+
+class TranscriptFinalMessage(BaseModel):
+    """Final transcript for logging."""
+    type: str = Field(default="transcript_final", description="Message type")
+    text: str = Field(..., description="Final transcribed text")
+    role: str = Field(..., description="Speaker role (user, assistant)")
+    duration_ms: int = Field(..., description="Duration in milliseconds")
+    confidence: float = Field(..., description="Confidence score (0.0-1.0)")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Voice metadata")
+    timestamp: str = Field(..., description="ISO timestamp")
+
+
+class AudioChunkMessage(BaseModel):
+    """Audio chunk message."""
+    type: str = Field(default="audio", description="Message type")
+    data: str = Field(..., description="Base64-encoded audio data")
+    mime_type: str = Field(default="audio/pcm", description="Audio MIME type")
+    sequence: Optional[int] = Field(None, description="Sequence number for ordering")
+    timestamp: str = Field(..., description="ISO timestamp")
+
+
+class TurnStatusMessage(BaseModel):
+    """Turn status update."""
+    type: str = Field(default="turn_status", description="Message type")
+    turn_complete: bool = Field(..., description="Whether turn is complete")
+    interrupted: bool = Field(default=False, description="Whether turn was interrupted")
+    timestamp: str = Field(..., description="ISO timestamp")
+
+
+class VoiceSessionInfo(BaseModel):
+    """Voice session information."""
+    session_id: str = Field(..., description="Session ID")
+    user_id: str = Field(..., description="User ID")
+    character_id: Optional[str] = Field(None, description="Character ID")
+    scenario_id: Optional[str] = Field(None, description="Scenario ID")
+    language: str = Field(default="en", description="Session language")
+    started_at: Optional[str] = Field(None, description="Session start timestamp")
+    transcript_available: bool = Field(default=False, description="Whether transcripts are available")
+
+
+class VoiceSessionStats(BaseModel):
+    """Voice session statistics."""
+    session_id: str = Field(..., description="Session ID")
+    started_at: str = Field(..., description="Session start timestamp")
+    ended_at: Optional[str] = Field(None, description="Session end timestamp")
+    duration_ms: Optional[int] = Field(None, description="Session duration in milliseconds")
+    audio_chunks_sent: int = Field(default=0, description="Audio chunks sent to server")
+    audio_chunks_received: int = Field(default=0, description="Audio chunks received from server")
+    transcripts_processed: int = Field(default=0, description="Total transcripts processed")
+    total_utterances: int = Field(default=0, description="Total finalized utterances")
+    total_partials: int = Field(default=0, description="Total partial transcripts processed")
+    errors: int = Field(default=0, description="Number of errors encountered")
+
+
+class VoiceMessage(BaseModel):
+    """Voice message for ChatLogger integration."""
+    type: str = Field(default="voice_message", description="Message type")
+    role: str = Field(..., description="Speaker role (user, assistant)")
+    text: str = Field(..., description="Transcribed text")
+    timestamp: str = Field(..., description="ISO timestamp")
+    voice_metadata: Dict[str, Any] = Field(default_factory=dict, description="Voice-specific metadata")
+    
+    class Config:
+        """Pydantic configuration."""
+        extra = "allow"  # Allow additional fields for compatibility
+
+
+class VoiceSessionRequest(BaseModel):
+    """Request to create or join a voice session."""
+    session_id: str = Field(..., description="Session ID to join")
+    character_id: Optional[str] = Field(None, description="Character ID (if creating new)")
+    scenario_id: Optional[str] = Field(None, description="Scenario ID (if creating new)")
+    language: Optional[str] = Field("en", description="Language preference")
+    transcript_config: Optional[Dict[str, Any]] = Field(None, description="Transcript buffer configuration")
+
+
+class VoiceSessionResponse(BaseResponse):
+    """Response from voice session operations."""
+    session_info: Optional[VoiceSessionInfo] = None
+    stats: Optional[VoiceSessionStats] = None
+
+
+# Union type for all possible WebSocket messages from server to client
+VoiceServerMessage = Union[
+    VoiceConfigMessage,
+    VoiceStatusMessage,
+    VoiceErrorMessage,
+    TranscriptPartialMessage,
+    TranscriptFinalMessage,
+    AudioChunkMessage,
+    TurnStatusMessage
+]
+
+
+# Union type for all possible WebSocket messages from client to server
+VoiceClientMessage = Union[VoiceClientRequest]
+
+
+class VoiceTranscriptConfig(BaseModel):
+    """Configuration for transcript buffering."""
+    stability_threshold: float = Field(default=0.8, description="Minimum stability for partial acceptance")
+    finalization_timeout_ms: int = Field(default=2000, description="Timeout for finalizing partials")
+    min_utterance_length: int = Field(default=3, description="Minimum words for logging utterance")
+    sentence_boundary_patterns: List[str] = Field(
+        default_factory=lambda: [r'[.!?]+\s*$', r'\n+'],
+        description="Regex patterns for sentence boundaries"
+    )
+
+
+class VoiceBufferStats(BaseModel):
+    """Statistics from transcript buffering."""
+    pending_user_segments: int = Field(..., description="Pending user transcript segments")
+    pending_assistant_segments: int = Field(..., description="Pending assistant transcript segments")
+    total_utterances: int = Field(..., description="Total finalized utterances")
+    total_partials: int = Field(..., description="Total partial segments processed")
+    started_at: str = Field(..., description="Buffer start timestamp")

--- a/src/python/role_play/voice/transcript_manager.py
+++ b/src/python/role_play/voice/transcript_manager.py
@@ -56,7 +56,7 @@ class TranscriptBuffer:
         
         # Default sentence boundary patterns
         self.sentence_patterns = sentence_boundary_patterns or [
-            r'[.!?]+\s*$',  # Sentence endings
+            r'[.!?]+',      # Sentence endings (removed $ to match all, not just end)
             r'\n+',         # Line breaks
         ]
         self._compiled_patterns = [re.compile(pattern) for pattern in self.sentence_patterns]

--- a/src/python/role_play/voice/transcript_manager.py
+++ b/src/python/role_play/voice/transcript_manager.py
@@ -1,0 +1,308 @@
+"""Intelligent transcript management for voice chat sessions."""
+
+import asyncio
+import re
+import logging
+from typing import Optional, List, Dict, Any, Tuple
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from ..common.time_utils import utc_now_isoformat, utc_now
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptSegment:
+    """Represents a segment of transcribed speech."""
+    text: str
+    stability: float
+    is_final: bool
+    timestamp: str
+    confidence: Optional[float] = None
+    role: str = "user"  # "user" or "assistant"
+    sequence: int = 0
+
+
+@dataclass
+class BufferedTranscript:
+    """A transcript ready for logging with metadata."""
+    text: str
+    role: str
+    timestamp: str
+    duration_ms: int
+    confidence: float
+    partial_count: int
+    voice_metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class TranscriptBuffer:
+    """
+    Manages transcript buffering with intelligent partial/final handling.
+    
+    Handles the conversion from fragmented real-time speech recognition
+    into coherent, loggable text segments.
+    """
+    
+    def __init__(
+        self, 
+        stability_threshold: float = 0.8,
+        finalization_timeout_ms: int = 2000,
+        min_utterance_length: int = 3,
+        sentence_boundary_patterns: Optional[List[str]] = None
+    ):
+        self.stability_threshold = stability_threshold
+        self.finalization_timeout_ms = finalization_timeout_ms
+        self.min_utterance_length = min_utterance_length
+        
+        # Default sentence boundary patterns
+        self.sentence_patterns = sentence_boundary_patterns or [
+            r'[.!?]+\s*$',  # Sentence endings
+            r'\n+',         # Line breaks
+        ]
+        self._compiled_patterns = [re.compile(pattern) for pattern in self.sentence_patterns]
+        
+        # Buffers
+        self.partial_segments: List[TranscriptSegment] = []
+        self.final_segments: List[TranscriptSegment] = []
+        self.pending_finalization: List[TranscriptSegment] = []
+        
+        # State tracking
+        self.last_activity_time = utc_now()
+        self.sequence_counter = 0
+        self._finalization_task: Optional[asyncio.Task] = None
+
+    async def add_segment(self, segment: TranscriptSegment) -> Tuple[Optional[str], Optional[BufferedTranscript]]:
+        """
+        Add a transcript segment and return display text and any finalized transcript.
+        
+        Args:
+            segment: New transcript segment from speech recognition
+            
+        Returns:
+            Tuple of (display_text, finalized_transcript)
+            - display_text: Text for immediate UI display (may be partial)
+            - finalized_transcript: Complete transcript ready for logging (None if not ready)
+        """
+        self.last_activity_time = utc_now()
+        segment.sequence = self.sequence_counter
+        self.sequence_counter += 1
+        
+        logger.debug(f"Adding segment: '{segment.text}' (final={segment.is_final}, stability={segment.stability})")
+        
+        finalized_transcript = None
+        
+        if segment.is_final:
+            # Final result - replace all partials and finalize
+            finalized_transcript = await self._finalize_segments(segment)
+            self.partial_segments.clear()
+            self.final_segments.append(segment)
+        else:
+            # Partial result
+            if segment.stability >= self.stability_threshold:
+                # High stability - likely to be accurate
+                self.partial_segments.append(segment)
+            else:
+                # Low stability - replace previous partials
+                self.partial_segments = [segment]
+        
+        # Schedule timeout-based finalization
+        await self._schedule_finalization()
+        
+        display_text = self._get_display_text()
+        return display_text, finalized_transcript
+
+    async def _finalize_segments(self, final_segment: TranscriptSegment) -> Optional[BufferedTranscript]:
+        """Convert accumulated segments into a finalized transcript."""
+        if not final_segment.text.strip():
+            return None
+            
+        # Calculate metadata
+        partial_count = len(self.partial_segments)
+        text = final_segment.text.strip()
+        
+        # Check minimum utterance length
+        word_count = len(text.split())
+        if word_count < self.min_utterance_length:
+            logger.debug(f"Utterance too short ({word_count} words): '{text}'")
+            return None
+        
+        # Calculate duration (rough estimate from segments)
+        start_time = self.partial_segments[0].timestamp if self.partial_segments else final_segment.timestamp
+        duration_ms = self._calculate_duration(start_time, final_segment.timestamp)
+        
+        buffered_transcript = BufferedTranscript(
+            text=text,
+            role=final_segment.role,
+            timestamp=final_segment.timestamp,
+            duration_ms=duration_ms,
+            confidence=final_segment.confidence or 0.0,
+            partial_count=partial_count,
+            voice_metadata={
+                "stability_threshold": self.stability_threshold,
+                "sentence_boundaries": self._detect_sentence_boundaries(text),
+                "word_count": word_count
+            }
+        )
+        
+        logger.info(f"Finalized transcript: '{text}' ({duration_ms}ms, {partial_count} partials)")
+        return buffered_transcript
+
+    async def _schedule_finalization(self):
+        """Schedule timeout-based finalization for pending segments."""
+        if self._finalization_task:
+            self._finalization_task.cancel()
+        
+        if self.partial_segments:
+            self._finalization_task = asyncio.create_task(
+                self._timeout_finalization()
+            )
+
+    async def _timeout_finalization(self):
+        """Finalize segments after timeout if no final result received."""
+        try:
+            await asyncio.sleep(self.finalization_timeout_ms / 1000.0)
+            
+            if self.partial_segments:
+                logger.debug(f"Timeout finalization of {len(self.partial_segments)} partial segments")
+                
+                # Create a synthetic final segment from the most stable partial
+                best_partial = max(self.partial_segments, key=lambda s: s.stability)
+                synthetic_final = TranscriptSegment(
+                    text=best_partial.text,
+                    stability=best_partial.stability,
+                    is_final=True,  # Mark as final for processing
+                    timestamp=utc_now_isoformat(),
+                    confidence=best_partial.confidence,
+                    role=best_partial.role,
+                    sequence=best_partial.sequence
+                )
+                
+                finalized = await self._finalize_segments(synthetic_final)
+                if finalized:
+                    # Would need callback mechanism to handle this
+                    logger.info(f"Timeout-finalized transcript: '{finalized.text}'")
+                
+                self.partial_segments.clear()
+                self.final_segments.append(synthetic_final)
+                
+        except asyncio.CancelledError:
+            pass  # Normal cancellation
+
+    def _get_display_text(self) -> str:
+        """Get text for immediate display (includes partials)."""
+        all_segments = self.final_segments + self.partial_segments
+        if not all_segments:
+            return ""
+        
+        # Sort by sequence to maintain order
+        sorted_segments = sorted(all_segments, key=lambda s: s.sequence)
+        return " ".join(segment.text for segment in sorted_segments if segment.text.strip())
+
+    def _detect_sentence_boundaries(self, text: str) -> List[int]:
+        """Detect sentence boundaries in text."""
+        boundaries = []
+        for pattern in self._compiled_patterns:
+            for match in pattern.finditer(text):
+                boundaries.append(match.start())
+        return sorted(boundaries)
+
+    def _calculate_duration(self, start_timestamp: str, end_timestamp: str) -> int:
+        """Calculate duration between timestamps in milliseconds."""
+        try:
+            start_dt = datetime.fromisoformat(start_timestamp.replace('Z', '+00:00'))
+            end_dt = datetime.fromisoformat(end_timestamp.replace('Z', '+00:00'))
+            delta = end_dt - start_dt
+            return int(delta.total_seconds() * 1000)
+        except (ValueError, AttributeError):
+            return 0
+
+    def get_pending_count(self) -> int:
+        """Get count of pending partial segments."""
+        return len(self.partial_segments)
+
+    def clear(self):
+        """Clear all buffers."""
+        self.partial_segments.clear()
+        self.final_segments.clear()
+        self.pending_finalization.clear()
+        if self._finalization_task:
+            self._finalization_task.cancel()
+            self._finalization_task = None
+
+    async def flush(self) -> List[BufferedTranscript]:
+        """Force finalization of all pending segments."""
+        finalized_transcripts = []
+        
+        if self.partial_segments:
+            # Force finalize all partials
+            for partial in self.partial_segments:
+                synthetic_final = TranscriptSegment(
+                    text=partial.text,
+                    stability=partial.stability,
+                    is_final=True,
+                    timestamp=utc_now_isoformat(),
+                    confidence=partial.confidence,
+                    role=partial.role,
+                    sequence=partial.sequence
+                )
+                
+                finalized = await self._finalize_segments(synthetic_final)
+                if finalized:
+                    finalized_transcripts.append(finalized)
+        
+        self.clear()
+        return finalized_transcripts
+
+
+class SessionTranscriptManager:
+    """
+    Manages transcript buffers for an entire voice session.
+    
+    Handles separate buffers for user and assistant speech,
+    and coordinates batch logging to ChatLogger.
+    """
+    
+    def __init__(self, **buffer_kwargs):
+        self.user_buffer = TranscriptBuffer(**buffer_kwargs)
+        self.assistant_buffer = TranscriptBuffer(**buffer_kwargs)
+        self.session_metadata = {
+            "started_at": utc_now_isoformat(),
+            "total_utterances": 0,
+            "total_partials": 0,
+        }
+
+    async def add_user_segment(self, segment: TranscriptSegment) -> Tuple[Optional[str], Optional[BufferedTranscript]]:
+        """Add user speech segment."""
+        segment.role = "user"
+        display_text, finalized = await self.user_buffer.add_segment(segment)
+        
+        if finalized:
+            self.session_metadata["total_utterances"] += 1
+            self.session_metadata["total_partials"] += finalized.partial_count
+            
+        return display_text, finalized
+
+    async def add_assistant_segment(self, segment: TranscriptSegment) -> Tuple[Optional[str], Optional[BufferedTranscript]]:
+        """Add assistant speech segment."""
+        segment.role = "assistant"
+        display_text, finalized = await self.assistant_buffer.add_segment(segment)
+        
+        if finalized:
+            self.session_metadata["total_utterances"] += 1
+            self.session_metadata["total_partials"] += finalized.partial_count
+            
+        return display_text, finalized
+
+    async def flush_all(self) -> List[BufferedTranscript]:
+        """Flush all pending transcripts."""
+        user_transcripts = await self.user_buffer.flush()
+        assistant_transcripts = await self.assistant_buffer.flush()
+        return user_transcripts + assistant_transcripts
+
+    def get_session_stats(self) -> Dict[str, Any]:
+        """Get session-level statistics."""
+        return {
+            **self.session_metadata,
+            "pending_user_segments": self.user_buffer.get_pending_count(),
+            "pending_assistant_segments": self.assistant_buffer.get_pending_count(),
+        }

--- a/src/ts/role_play/ui/src/components/VoiceTranscript.vue
+++ b/src/ts/role_play/ui/src/components/VoiceTranscript.vue
@@ -1,0 +1,502 @@
+<template>
+  <div class="voice-transcript">
+    <!-- Transcript Display -->
+    <div class="transcript-container" ref="transcriptContainer">
+      <div class="transcript-content">
+        <!-- Final transcript messages -->
+        <div
+          v-for="message in finalMessages"
+          :key="message.id"
+          :class="['message', `message--${message.role}`]"
+        >
+          <div class="message__header">
+            <span class="message__role">{{ formatRole(message.role) }}</span>
+            <span class="message__timestamp">{{ formatTimestamp(message.timestamp) }}</span>
+            <span v-if="message.duration" class="message__duration">
+              {{ formatDuration(message.duration) }}
+            </span>
+          </div>
+          <div class="message__text">{{ message.text }}</div>
+          <div v-if="message.isVoice" class="message__voice-indicator">
+            <span class="voice-badge">🎤 Voice</span>
+            <span v-if="message.confidence" class="confidence-score">
+              {{ Math.round(message.confidence * 100) }}%
+            </span>
+          </div>
+        </div>
+
+        <!-- Partial transcript (live updates) -->
+        <div
+          v-if="partialMessage && partialMessage.text.trim()"
+          :class="['message', 'message--partial', `message--${partialMessage.role}`]"
+        >
+          <div class="message__header">
+            <span class="message__role">{{ formatRole(partialMessage.role) }}</span>
+            <span class="message__status">{{ $t('chat.voice.speaking') }}</span>
+          </div>
+          <div class="message__text">
+            {{ partialMessage.text }}
+            <span 
+              class="stability-indicator"
+              :style="{ opacity: partialMessage.stability }"
+              :title="`${$t('chat.voice.stability')}: ${Math.round((partialMessage.stability || 0) * 100)}%`"
+            >
+              ●
+            </span>
+          </div>
+        </div>
+
+        <!-- Typing indicator -->
+        <div v-if="isProcessing" class="typing-indicator">
+          <div class="typing-dots">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+          <span class="typing-text">{{ $t('chat.voice.processing') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Voice Controls -->
+    <div class="voice-controls">
+      <button
+        v-if="!isConnected"
+        @click="connect"
+        :disabled="isConnecting"
+        class="voice-btn voice-btn--connect"
+      >
+        <span v-if="isConnecting">{{ $t('chat.voice.connecting') }}</span>
+        <span v-else>{{ $t('chat.voice.connect') }}</span>
+      </button>
+
+      <template v-else>
+        <!-- Recording Controls -->
+        <div class="recording-controls">
+          <button
+            @click="toggleRecording"
+            :class="['voice-btn', 'voice-btn--record', { 'voice-btn--recording': isRecording }]"
+            :disabled="!canRecord"
+          >
+            <span v-if="isRecording">{{ $t('chat.voice.stop') }}</span>
+            <span v-else>{{ $t('chat.voice.startRecording') }}</span>
+          </button>
+
+          <!-- Text Input Fallback -->
+          <div class="text-input-fallback">
+            <input
+              v-model="textInput"
+              @keyup.enter="sendText"
+              :placeholder="$t('chat.voice.textFallback')"
+              class="text-input"
+            />
+            <button 
+              @click="sendText"
+              :disabled="!textInput.trim()"
+              class="voice-btn voice-btn--send"
+            >
+              {{ $t('chat.voice.send') }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Session Controls -->
+        <div class="session-controls">
+          <button
+            @click="disconnect"
+            class="voice-btn voice-btn--disconnect"
+          >
+            {{ $t('chat.voice.disconnect') }}
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- Connection Status -->
+    <div v-if="connectionStatus" :class="['status-indicator', `status--${connectionStatus.type}`]">
+      {{ connectionStatus.message }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useTranscriptBuffer } from '../composables/useTranscriptBuffer'
+import { useVoiceWebSocket } from '../composables/useVoiceWebSocket'
+import type { TranscriptMessage, VoiceStatus } from '../types/voice'
+
+// Component Props
+interface Props {
+  sessionId: string
+  token: string
+  autoConnect?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  autoConnect: false
+})
+
+// Composables
+const { t } = useI18n()
+const {
+  finalMessages,
+  partialMessage,
+  addPartialTranscript,
+  addFinalTranscript,
+  clear
+} = useTranscriptBuffer()
+
+const {
+  isConnected,
+  isConnecting,
+  isRecording,
+  canRecord,
+  connectionStatus,
+  connect: connectWS,
+  disconnect: disconnectWS,
+  startRecording,
+  stopRecording,
+  sendTextMessage
+} = useVoiceWebSocket({
+  sessionId: props.sessionId,
+  token: props.token,
+  onPartialTranscript: addPartialTranscript,
+  onFinalTranscript: addFinalTranscript,
+  onStatusChange: (status: VoiceStatus) => {
+    console.log('Voice status:', status)
+  }
+})
+
+// Local state
+const textInput = ref('')
+const isProcessing = ref(false)
+const transcriptContainer = ref<HTMLElement>()
+
+// Methods
+const connect = async () => {
+  try {
+    await connectWS()
+  } catch (error) {
+    console.error('Failed to connect:', error)
+  }
+}
+
+const disconnect = async () => {
+  await disconnectWS()
+  clear()
+}
+
+const toggleRecording = async () => {
+  if (isRecording.value) {
+    await stopRecording()
+  } else {
+    await startRecording()
+  }
+}
+
+const sendText = async () => {
+  if (!textInput.value.trim()) return
+  
+  try {
+    await sendTextMessage(textInput.value)
+    textInput.value = ''
+  } catch (error) {
+    console.error('Failed to send text:', error)
+  }
+}
+
+const formatRole = (role: string): string => {
+  return role === 'user' ? t('chat.voice.you') : t('chat.voice.character')
+}
+
+const formatTimestamp = (timestamp: string): string => {
+  return new Date(timestamp).toLocaleTimeString()
+}
+
+const formatDuration = (duration: number): string => {
+  return `${(duration / 1000).toFixed(1)}s`
+}
+
+// Auto-scroll to bottom when new messages arrive
+const scrollToBottom = async () => {
+  await nextTick()
+  if (transcriptContainer.value) {
+    transcriptContainer.value.scrollTop = transcriptContainer.value.scrollHeight
+  }
+}
+
+// Watch for new messages and scroll
+const messageCount = computed(() => finalMessages.value.length)
+watch(messageCount, scrollToBottom)
+watch(() => partialMessage.value?.text, scrollToBottom)
+
+// Lifecycle
+onMounted(() => {
+  if (props.autoConnect) {
+    connect()
+  }
+})
+
+onUnmounted(() => {
+  disconnect()
+})
+</script>
+
+<style scoped>
+.voice-transcript {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.transcript-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  max-height: 400px;
+}
+
+.transcript-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #f0f0f0;
+}
+
+.message--user {
+  background: #e3f2fd;
+  margin-left: 20%;
+  align-self: flex-end;
+}
+
+.message--assistant {
+  background: #f5f5f5;
+  margin-right: 20%;
+  align-self: flex-start;
+}
+
+.message--partial {
+  border: 2px dashed #2196f3;
+  animation: pulse 2s infinite;
+}
+
+.message__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 0.85em;
+  color: #666;
+}
+
+.message__role {
+  font-weight: 600;
+}
+
+.message__timestamp {
+  font-family: monospace;
+}
+
+.message__duration {
+  font-size: 0.8em;
+  background: #e0e0e0;
+  padding: 2px 6px;
+  border-radius: 12px;
+}
+
+.message__status {
+  font-style: italic;
+  color: #2196f3;
+}
+
+.message__text {
+  font-size: 1em;
+  line-height: 1.4;
+  position: relative;
+}
+
+.message__voice-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 0.8em;
+}
+
+.voice-badge {
+  background: #4caf50;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75em;
+}
+
+.confidence-score {
+  background: #f0f0f0;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-family: monospace;
+}
+
+.stability-indicator {
+  color: #2196f3;
+  font-weight: bold;
+  animation: pulse 1s infinite;
+  margin-left: 4px;
+}
+
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #f9f9f9;
+  border-radius: 8px;
+  font-style: italic;
+  color: #666;
+}
+
+.typing-dots {
+  display: flex;
+  gap: 4px;
+}
+
+.typing-dots span {
+  width: 4px;
+  height: 4px;
+  background: #2196f3;
+  border-radius: 50%;
+  animation: typing-dots 1.4s infinite ease-in-out;
+}
+
+.typing-dots span:nth-child(1) { animation-delay: -0.32s; }
+.typing-dots span:nth-child(2) { animation-delay: -0.16s; }
+
+.voice-controls {
+  padding: 16px;
+  border-top: 1px solid #e0e0e0;
+  background: #fafafa;
+  border-radius: 0 0 8px 8px;
+}
+
+.recording-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.text-input-fallback {
+  display: flex;
+  gap: 8px;
+}
+
+.text-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.session-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.voice-btn {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.voice-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.voice-btn--connect {
+  background: #4caf50;
+  color: white;
+}
+
+.voice-btn--connect:hover:not(:disabled) {
+  background: #43a047;
+}
+
+.voice-btn--record {
+  background: #2196f3;
+  color: white;
+}
+
+.voice-btn--record:hover:not(:disabled) {
+  background: #1976d2;
+}
+
+.voice-btn--recording {
+  background: #f44336;
+  animation: pulse 1.5s infinite;
+}
+
+.voice-btn--send {
+  background: #2196f3;
+  color: white;
+}
+
+.voice-btn--disconnect {
+  background: #f44336;
+  color: white;
+}
+
+.voice-btn--disconnect:hover {
+  background: #d32f2f;
+}
+
+.status-indicator {
+  padding: 8px 16px;
+  font-size: 0.85em;
+  border-top: 1px solid #e0e0e0;
+}
+
+.status--connected {
+  background: #e8f5e8;
+  color: #2e7d32;
+}
+
+.status--error {
+  background: #ffebee;
+  color: #c62828;
+}
+
+.status--connecting {
+  background: #fff3e0;
+  color: #f57c00;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+@keyframes typing-dots {
+  0%, 80%, 100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1);
+  }
+}
+</style>

--- a/src/ts/role_play/ui/src/composables/useTranscriptBuffer.ts
+++ b/src/ts/role_play/ui/src/composables/useTranscriptBuffer.ts
@@ -1,0 +1,199 @@
+/**
+ * Composable for managing transcript buffering on the frontend.
+ * Mirrors the backend transcript management logic for consistent UX.
+ */
+
+import { ref, computed } from 'vue'
+import type { TranscriptMessage, PartialTranscript, FinalTranscript } from '../types/voice'
+
+interface TranscriptBufferConfig {
+  stabilityThreshold?: number
+  maxPartialAge?: number // milliseconds
+}
+
+export function useTranscriptBuffer(config: TranscriptBufferConfig = {}) {
+  const {
+    stabilityThreshold = 0.8,
+    maxPartialAge = 5000 // 5 seconds
+  } = config
+
+  // State
+  const finalMessages = ref<TranscriptMessage[]>([])
+  const partialMessage = ref<PartialTranscript | null>(null)
+  const messageCounter = ref(0)
+
+  // Computed
+  const hasMessages = computed(() => finalMessages.value.length > 0)
+  const displayText = computed(() => {
+    const finalText = finalMessages.value.map(m => m.text).join(' ')
+    const partialText = partialMessage.value?.text || ''
+    return [finalText, partialText].filter(Boolean).join(' ')
+  })
+
+  // Methods
+  const addPartialTranscript = (partial: PartialTranscript) => {
+    // Update partial message for live display
+    partialMessage.value = {
+      ...partial,
+      timestamp: partial.timestamp || new Date().toISOString()
+    }
+
+    // Clean up old partial if it's been too long
+    if (partialMessage.value) {
+      const age = Date.now() - new Date(partialMessage.value.timestamp).getTime()
+      if (age > maxPartialAge) {
+        partialMessage.value = null
+      }
+    }
+  }
+
+  const addFinalTranscript = (final: FinalTranscript) => {
+    // Clear any partial message for this role
+    if (partialMessage.value && partialMessage.value.role === final.role) {
+      partialMessage.value = null
+    }
+
+    // Add to final messages
+    const message: TranscriptMessage = {
+      id: `msg-${Date.now()}-${messageCounter.value++}`,
+      text: final.text,
+      role: final.role,
+      timestamp: final.timestamp || new Date().toISOString(),
+      isVoice: true,
+      duration: final.duration_ms,
+      confidence: final.confidence,
+      metadata: final.metadata || {}
+    }
+
+    finalMessages.value.push(message)
+
+    // Keep only recent messages to prevent memory bloat
+    if (finalMessages.value.length > 100) {
+      finalMessages.value = finalMessages.value.slice(-80) // Keep last 80 messages
+    }
+  }
+
+  const addTextMessage = (text: string, role: 'user' | 'assistant') => {
+    const message: TranscriptMessage = {
+      id: `text-${Date.now()}-${messageCounter.value++}`,
+      text,
+      role,
+      timestamp: new Date().toISOString(),
+      isVoice: false
+    }
+
+    finalMessages.value.push(message)
+  }
+
+  const updatePartialStability = (stability: number) => {
+    if (partialMessage.value) {
+      partialMessage.value.stability = stability
+    }
+  }
+
+  const clear = () => {
+    finalMessages.value = []
+    partialMessage.value = null
+    messageCounter.value = 0
+  }
+
+  const getMessageById = (id: string): TranscriptMessage | undefined => {
+    return finalMessages.value.find(m => m.id === id)
+  }
+
+  const getMessagesInRange = (startTime: string, endTime: string): TranscriptMessage[] => {
+    const start = new Date(startTime).getTime()
+    const end = new Date(endTime).getTime()
+    
+    return finalMessages.value.filter(message => {
+      const msgTime = new Date(message.timestamp).getTime()
+      return msgTime >= start && msgTime <= end
+    })
+  }
+
+  const exportTranscript = (): string => {
+    const lines = finalMessages.value.map(message => {
+      const timestamp = new Date(message.timestamp).toLocaleTimeString()
+      const roleLabel = message.role === 'user' ? 'You' : 'Character'
+      const voiceLabel = message.isVoice ? ' [Voice]' : ''
+      const durationLabel = message.duration ? ` (${(message.duration / 1000).toFixed(1)}s)` : ''
+      
+      return `[${timestamp}] ${roleLabel}${voiceLabel}${durationLabel}: ${message.text}`
+    })
+    
+    return lines.join('\n')
+  }
+
+  const getStatistics = () => {
+    const totalMessages = finalMessages.value.length
+    const voiceMessages = finalMessages.value.filter(m => m.isVoice).length
+    const textMessages = totalMessages - voiceMessages
+    const averageConfidence = finalMessages.value
+      .filter(m => m.confidence !== undefined)
+      .reduce((sum, m) => sum + (m.confidence || 0), 0) / voiceMessages || 0
+    
+    const totalDuration = finalMessages.value
+      .filter(m => m.duration !== undefined)
+      .reduce((sum, m) => sum + (m.duration || 0), 0)
+
+    return {
+      totalMessages,
+      voiceMessages,
+      textMessages,
+      averageConfidence: Math.round(averageConfidence * 100) / 100,
+      totalDurationMs: totalDuration,
+      totalDurationSeconds: Math.round(totalDuration / 1000 * 10) / 10
+    }
+  }
+
+  // Auto-cleanup for old partial messages
+  let partialCleanupInterval: NodeJS.Timeout | null = null
+  
+  const startPartialCleanup = () => {
+    if (partialCleanupInterval) return
+    
+    partialCleanupInterval = setInterval(() => {
+      if (partialMessage.value) {
+        const age = Date.now() - new Date(partialMessage.value.timestamp).getTime()
+        if (age > maxPartialAge) {
+          partialMessage.value = null
+        }
+      }
+    }, 1000) // Check every second
+  }
+
+  const stopPartialCleanup = () => {
+    if (partialCleanupInterval) {
+      clearInterval(partialCleanupInterval)
+      partialCleanupInterval = null
+    }
+  }
+
+  // Start cleanup on initialization
+  startPartialCleanup()
+
+  return {
+    // State
+    finalMessages: readonly(finalMessages),
+    partialMessage: readonly(partialMessage),
+    
+    // Computed
+    hasMessages,
+    displayText,
+    
+    // Methods
+    addPartialTranscript,
+    addFinalTranscript,
+    addTextMessage,
+    updatePartialStability,
+    clear,
+    getMessageById,
+    getMessagesInRange,
+    exportTranscript,
+    getStatistics,
+    
+    // Lifecycle
+    startPartialCleanup,
+    stopPartialCleanup
+  }
+}

--- a/src/ts/role_play/ui/src/composables/useVoiceWebSocket.ts
+++ b/src/ts/role_play/ui/src/composables/useVoiceWebSocket.ts
@@ -1,0 +1,444 @@
+/**
+ * Composable for managing voice WebSocket connections with audio streaming.
+ */
+
+import { ref, onUnmounted } from 'vue'
+import type { 
+  VoiceStatus, 
+  PartialTranscript, 
+  FinalTranscript,
+  VoiceConfig,
+  AudioChunk,
+  TurnStatus
+} from '../types/voice'
+
+interface VoiceWebSocketConfig {
+  sessionId: string
+  token: string
+  onPartialTranscript?: (transcript: PartialTranscript) => void
+  onFinalTranscript?: (transcript: FinalTranscript) => void
+  onAudioChunk?: (chunk: AudioChunk) => void
+  onTurnStatus?: (status: TurnStatus) => void
+  onStatusChange?: (status: VoiceStatus) => void
+  onError?: (error: string) => void
+}
+
+export function useVoiceWebSocket(config: VoiceWebSocketConfig) {
+  // State
+  const isConnected = ref(false)
+  const isConnecting = ref(false)
+  const isRecording = ref(false)
+  const canRecord = ref(false)
+  const connectionStatus = ref<VoiceStatus | null>(null)
+  const voiceConfig = ref<VoiceConfig | null>(null)
+
+  // WebSocket and audio references
+  let websocket: WebSocket | null = null
+  let mediaRecorder: MediaRecorder | null = null
+  let audioContext: AudioContext | null = null
+  let audioWorkletNode: AudioWorkletNode | null = null
+  let audioStream: MediaStream | null = null
+  let audioQueue: Float32Array[] = []
+  let isPlaying = ref(false)
+
+  // Audio configuration
+  const SAMPLE_RATE = 16000
+  const CHANNELS = 1
+  const CHUNK_SIZE = 1600 // 100ms at 16kHz
+
+  // WebSocket connection
+  const connect = async (): Promise<void> => {
+    if (isConnected.value || isConnecting.value) {
+      return
+    }
+
+    isConnecting.value = true
+    connectionStatus.value = {
+      type: 'connecting',
+      message: 'Connecting to voice service...',
+      timestamp: new Date().toISOString()
+    }
+
+    try {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const host = window.location.host
+      const wsUrl = `${protocol}//${host}/api/voice/ws/${config.sessionId}?token=${config.token}`
+      
+      websocket = new WebSocket(wsUrl)
+      
+      websocket.onopen = () => {
+        isConnected.value = true
+        isConnecting.value = false
+        connectionStatus.value = {
+          type: 'connected',
+          message: 'Connected to voice service',
+          timestamp: new Date().toISOString()
+        }
+        config.onStatusChange?.(connectionStatus.value)
+      }
+
+      websocket.onmessage = async (event) => {
+        try {
+          const message = JSON.parse(event.data)
+          await handleWebSocketMessage(message)
+        } catch (error) {
+          console.error('Error parsing WebSocket message:', error)
+        }
+      }
+
+      websocket.onclose = (event) => {
+        isConnected.value = false
+        isConnecting.value = false
+        isRecording.value = false
+        canRecord.value = false
+        
+        connectionStatus.value = {
+          type: 'disconnected',
+          message: `Connection closed: ${event.reason || 'Unknown reason'}`,
+          timestamp: new Date().toISOString()
+        }
+        config.onStatusChange?.(connectionStatus.value)
+        
+        cleanup()
+      }
+
+      websocket.onerror = (error) => {
+        console.error('WebSocket error:', error)
+        connectionStatus.value = {
+          type: 'error',
+          message: 'Connection error occurred',
+          timestamp: new Date().toISOString()
+        }
+        config.onError?.('WebSocket connection failed')
+        config.onStatusChange?.(connectionStatus.value)
+      }
+
+    } catch (error) {
+      isConnecting.value = false
+      connectionStatus.value = {
+        type: 'error',
+        message: `Failed to connect: ${error}`,
+        timestamp: new Date().toISOString()
+      }
+      config.onError?.(`Connection failed: ${error}`)
+      config.onStatusChange?.(connectionStatus.value)
+      throw error
+    }
+  }
+
+  // Handle incoming WebSocket messages
+  const handleWebSocketMessage = async (message: any) => {
+    switch (message.type) {
+      case 'config':
+        voiceConfig.value = message as VoiceConfig
+        await initializeAudio()
+        break
+        
+      case 'status':
+        if (message.status === 'ready') {
+          canRecord.value = true
+        }
+        connectionStatus.value = {
+          type: message.status,
+          message: message.message,
+          timestamp: message.timestamp
+        }
+        config.onStatusChange?.(connectionStatus.value)
+        break
+        
+      case 'transcript_partial':
+        config.onPartialTranscript?.(message as PartialTranscript)
+        break
+        
+      case 'transcript_final':
+        config.onFinalTranscript?.(message as FinalTranscript)
+        break
+        
+      case 'audio':
+        await playAudioChunk(message as AudioChunk)
+        config.onAudioChunk?.(message as AudioChunk)
+        break
+        
+      case 'turn_status':
+        config.onTurnStatus?.(message as TurnStatus)
+        break
+        
+      case 'error':
+        config.onError?.(message.error)
+        connectionStatus.value = {
+          type: 'error',
+          message: message.error,
+          timestamp: message.timestamp
+        }
+        config.onStatusChange?.(connectionStatus.value)
+        break
+    }
+  }
+
+  // Initialize audio context and worklet
+  const initializeAudio = async () => {
+    try {
+      // Initialize AudioContext for playback
+      audioContext = new AudioContext({ sampleRate: SAMPLE_RATE })
+      
+      // Resume context if suspended (required for user interaction)
+      if (audioContext.state === 'suspended') {
+        await audioContext.resume()
+      }
+
+      console.log('Audio initialized:', {
+        sampleRate: audioContext.sampleRate,
+        state: audioContext.state
+      })
+      
+    } catch (error) {
+      console.error('Failed to initialize audio:', error)
+      config.onError?.(`Audio initialization failed: ${error}`)
+    }
+  }
+
+  // Start audio recording
+  const startRecording = async (): Promise<void> => {
+    if (!canRecord.value || isRecording.value) {
+      return
+    }
+
+    try {
+      // Request microphone access
+      audioStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          sampleRate: SAMPLE_RATE,
+          channelCount: CHANNELS,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true
+        }
+      })
+
+      // Create MediaRecorder for capturing audio
+      const options = {
+        mimeType: 'audio/webm;codecs=opus', // Fallback to available format
+        audioBitsPerSecond: 16000
+      }
+      
+      // Find a supported MIME type
+      const supportedTypes = [
+        'audio/webm;codecs=opus',
+        'audio/webm',
+        'audio/mp4',
+        'audio/wav'
+      ]
+      
+      const mimeType = supportedTypes.find(type => MediaRecorder.isTypeSupported(type))
+      if (mimeType) {
+        options.mimeType = mimeType
+      }
+
+      mediaRecorder = new MediaRecorder(audioStream, options)
+      let audioChunks: Blob[] = []
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunks.push(event.data)
+        }
+      }
+
+      mediaRecorder.onstop = async () => {
+        if (audioChunks.length > 0) {
+          const audioBlob = new Blob(audioChunks, { type: options.mimeType })
+          await sendAudioBlob(audioBlob)
+          audioChunks = []
+        }
+      }
+
+      // Start recording in chunks
+      mediaRecorder.start(100) // Record in 100ms chunks
+      isRecording.value = true
+
+      console.log('Recording started')
+
+    } catch (error) {
+      console.error('Failed to start recording:', error)
+      config.onError?.(`Recording failed: ${error}`)
+      throw error
+    }
+  }
+
+  // Stop audio recording
+  const stopRecording = async (): Promise<void> => {
+    if (!isRecording.value || !mediaRecorder) {
+      return
+    }
+
+    try {
+      mediaRecorder.stop()
+      isRecording.value = false
+      
+      // Stop all tracks to release microphone
+      if (audioStream) {
+        audioStream.getTracks().forEach(track => track.stop())
+        audioStream = null
+      }
+      
+      console.log('Recording stopped')
+      
+    } catch (error) {
+      console.error('Failed to stop recording:', error)
+      config.onError?.(`Failed to stop recording: ${error}`)
+    }
+  }
+
+  // Convert audio blob to PCM and send
+  const sendAudioBlob = async (blob: Blob): Promise<void> => {
+    if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+      return
+    }
+
+    try {
+      // Convert blob to array buffer
+      const arrayBuffer = await blob.arrayBuffer()
+      
+      // For now, send the raw audio data
+      // In production, you'd want to convert to PCM format
+      const base64Data = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)))
+      
+      const audioMessage = {
+        mime_type: 'audio/pcm',
+        data: base64Data,
+        end_session: false
+      }
+
+      websocket.send(JSON.stringify(audioMessage))
+      
+    } catch (error) {
+      console.error('Failed to send audio:', error)
+      config.onError?.(`Failed to send audio: ${error}`)
+    }
+  }
+
+  // Send text message
+  const sendTextMessage = async (text: string): Promise<void> => {
+    if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+      throw new Error('WebSocket not connected')
+    }
+
+    try {
+      const textMessage = {
+        mime_type: 'text/plain',
+        data: btoa(text),
+        end_session: false
+      }
+
+      websocket.send(JSON.stringify(textMessage))
+      
+    } catch (error) {
+      console.error('Failed to send text:', error)
+      config.onError?.(`Failed to send text: ${error}`)
+      throw error
+    }
+  }
+
+  // Play audio chunk
+  const playAudioChunk = async (audioChunk: AudioChunk): Promise<void> => {
+    if (!audioContext) {
+      return
+    }
+
+    try {
+      // Decode base64 audio data
+      const audioData = atob(audioChunk.data)
+      const audioBuffer = new ArrayBuffer(audioData.length)
+      const audioView = new Uint8Array(audioBuffer)
+      
+      for (let i = 0; i < audioData.length; i++) {
+        audioView[i] = audioData.charCodeAt(i)
+      }
+
+      // Decode audio buffer
+      const decodedBuffer = await audioContext.decodeAudioData(audioBuffer)
+      
+      // Create buffer source and play
+      const source = audioContext.createBufferSource()
+      source.buffer = decodedBuffer
+      source.connect(audioContext.destination)
+      source.start()
+
+    } catch (error) {
+      console.error('Failed to play audio chunk:', error)
+      // Don't throw here, just log the error to avoid breaking the flow
+    }
+  }
+
+  // Disconnect WebSocket
+  const disconnect = async (): Promise<void> => {
+    if (isRecording.value) {
+      await stopRecording()
+    }
+
+    if (websocket) {
+      // Send end session message
+      try {
+        if (websocket.readyState === WebSocket.OPEN) {
+          const endMessage = {
+            mime_type: 'text/plain',
+            data: '',
+            end_session: true
+          }
+          websocket.send(JSON.stringify(endMessage))
+        }
+      } catch (error) {
+        console.error('Failed to send end session message:', error)
+      }
+
+      websocket.close()
+      websocket = null
+    }
+
+    cleanup()
+  }
+
+  // Cleanup resources
+  const cleanup = () => {
+    isConnected.value = false
+    isConnecting.value = false
+    isRecording.value = false
+    canRecord.value = false
+
+    if (audioStream) {
+      audioStream.getTracks().forEach(track => track.stop())
+      audioStream = null
+    }
+
+    if (audioContext) {
+      audioContext.close()
+      audioContext = null
+    }
+
+    mediaRecorder = null
+    audioWorkletNode = null
+    audioQueue = []
+  }
+
+  // Cleanup on unmount
+  onUnmounted(() => {
+    disconnect()
+  })
+
+  return {
+    // State
+    isConnected: readonly(isConnected),
+    isConnecting: readonly(isConnecting),
+    isRecording: readonly(isRecording),
+    canRecord: readonly(canRecord),
+    connectionStatus: readonly(connectionStatus),
+    voiceConfig: readonly(voiceConfig),
+    isPlaying: readonly(isPlaying),
+
+    // Methods
+    connect,
+    disconnect,
+    startRecording,
+    stopRecording,
+    sendTextMessage
+  }
+}

--- a/src/ts/role_play/ui/src/locales/en.json
+++ b/src/ts/role_play/ui/src/locales/en.json
@@ -39,7 +39,27 @@
     "continueExistingSession": "View Previous Sessions:",
     "deleteSession": "Delete session",
     "confirmDeleteSession": "Are you sure you want to delete this session? This action cannot be undone.",
-    "confirmEndSession": "Are you sure you want to end this session? You will no longer be able to send messages."
+    "confirmEndSession": "Are you sure you want to end this session? You will no longer be able to send messages.",
+    "voice": {
+      "connect": "Start Voice Chat",
+      "connecting": "Connecting...",
+      "disconnect": "End Voice Chat",
+      "startRecording": "Start Talking",
+      "stop": "Stop Talking",
+      "send": "Send",
+      "textFallback": "Type your message...",
+      "speaking": "Speaking...",
+      "processing": "Processing...",
+      "stability": "Transcript Stability",
+      "you": "You",
+      "character": "Character",
+      "transcriptPlaceholder": "Your conversation will appear here...",
+      "permissionDenied": "Microphone permission denied",
+      "notSupported": "Voice chat not supported",
+      "connectionError": "Connection error",
+      "recordingError": "Recording error",
+      "playbackError": "Playback error"
+    }
   },
   "warnings": {
     "languageSwitch": "Switching language will hide scenarios in the current language until you switch back. Continue?",

--- a/src/ts/role_play/ui/src/locales/zh-TW.json
+++ b/src/ts/role_play/ui/src/locales/zh-TW.json
@@ -39,7 +39,27 @@
     "continueExistingSession": "查看先前對話：",
     "deleteSession": "刪除對話",
     "confirmDeleteSession": "確定要刪除此對話嗎？此操作無法復原。",
-    "confirmEndSession": "確定要結束此對話嗎？結束後將無法再發送訊息。"
+    "confirmEndSession": "確定要結束此對話嗎？結束後將無法再發送訊息。",
+    "voice": {
+      "connect": "開始語音對話",
+      "connecting": "連接中...",
+      "disconnect": "結束語音對話",
+      "startRecording": "開始說話",
+      "stop": "停止說話",
+      "send": "發送",
+      "textFallback": "輸入您的訊息...",
+      "speaking": "說話中...",
+      "processing": "處理中...",
+      "stability": "轉錄穩定度",
+      "you": "您",
+      "character": "角色",
+      "transcriptPlaceholder": "您的對話記錄將顯示在這裡...",
+      "permissionDenied": "麥克風權限被拒絕",
+      "notSupported": "不支援語音對話",
+      "connectionError": "連接錯誤",
+      "recordingError": "錄音錯誤",
+      "playbackError": "播放錯誤"
+    }
   },
   "warnings": {
     "languageSwitch": "切換語言將隱藏目前語言的情境，直到您切換回來。是否繼續？",

--- a/src/ts/role_play/ui/src/types/voice.ts
+++ b/src/ts/role_play/ui/src/types/voice.ts
@@ -1,0 +1,157 @@
+/**
+ * TypeScript type definitions for voice chat functionality.
+ */
+
+export interface VoiceConfig {
+  type: 'config'
+  audio_format: string
+  sample_rate: number
+  channels: number
+  bit_depth: number
+  language: string
+  voice_name: string
+  output_audio_format: string
+}
+
+export interface VoiceStatus {
+  type: 'status' | 'connected' | 'ready' | 'error' | 'disconnected' | 'connecting'
+  message: string
+  timestamp: string
+}
+
+export interface PartialTranscript {
+  type: 'transcript_partial'
+  text: string
+  role: 'user' | 'assistant'
+  stability: number
+  timestamp: string
+}
+
+export interface FinalTranscript {
+  type: 'transcript_final'
+  text: string
+  role: 'user' | 'assistant'
+  duration_ms: number
+  confidence: number
+  metadata: Record<string, any>
+  timestamp: string
+}
+
+export interface AudioChunk {
+  type: 'audio'
+  data: string // base64 encoded audio
+  mime_type: string
+  sequence?: number
+  timestamp: string
+}
+
+export interface TurnStatus {
+  type: 'turn_status'
+  turn_complete: boolean
+  interrupted: boolean
+  timestamp: string
+}
+
+export interface VoiceError {
+  type: 'error'
+  error: string
+  code?: string
+  timestamp: string
+}
+
+export interface TranscriptMessage {
+  id: string
+  text: string
+  role: 'user' | 'assistant'
+  timestamp: string
+  isVoice: boolean
+  duration?: number
+  confidence?: number
+  metadata?: Record<string, any>
+}
+
+export interface VoiceSessionInfo {
+  session_id: string
+  user_id: string
+  character_id?: string
+  scenario_id?: string
+  language: string
+  started_at?: string
+  transcript_available: boolean
+}
+
+export interface VoiceSessionStats {
+  session_id: string
+  started_at: string
+  ended_at?: string
+  duration_ms?: number
+  audio_chunks_sent: number
+  audio_chunks_received: number
+  transcripts_processed: number
+  total_utterances: number
+  total_partials: number
+  errors: number
+}
+
+export interface VoiceClientRequest {
+  mime_type: string
+  data: string // base64 encoded
+  end_session: boolean
+}
+
+// Union types for WebSocket messages
+export type VoiceServerMessage = 
+  | VoiceConfig
+  | VoiceStatus
+  | PartialTranscript
+  | FinalTranscript
+  | AudioChunk
+  | TurnStatus
+  | VoiceError
+
+export type VoiceClientMessage = VoiceClientRequest
+
+// Audio processing types
+export interface AudioBufferInfo {
+  sampleRate: number
+  channels: number
+  length: number
+  duration: number
+}
+
+export interface AudioProcessingOptions {
+  sampleRate?: number
+  channels?: number
+  bitDepth?: number
+  chunkSize?: number
+  enableEchoCancellation?: boolean
+  enableNoiseSuppression?: boolean
+  enableAutoGainControl?: boolean
+}
+
+// Transcript buffer configuration
+export interface TranscriptBufferConfig {
+  stabilityThreshold?: number
+  finalizationTimeout?: number
+  minUtteranceLength?: number
+  maxPartialAge?: number
+}
+
+// Voice chat statistics
+export interface VoiceChatStatistics {
+  totalMessages: number
+  voiceMessages: number
+  textMessages: number
+  averageConfidence: number
+  totalDurationMs: number
+  totalDurationSeconds: number
+}
+
+// WebSocket connection states
+export type WebSocketState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'error'
+
+// Audio recording states
+export type RecordingState = 'idle' | 'starting' | 'recording' | 'stopping' | 'error'
+
+// Audio playback states
+export type PlaybackState = 'idle' | 'playing' | 'paused' | 'buffering' | 'error'

--- a/test/python/unit/voice/__init__.py
+++ b/test/python/unit/voice/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for voice chat functionality."""

--- a/test/python/unit/voice/test_transcript_manager.py
+++ b/test/python/unit/voice/test_transcript_manager.py
@@ -134,8 +134,9 @@ class TestTranscriptBuffer:
     async def test_sentence_boundary_detection(self, transcript_buffer):
         """Test sentence boundary detection."""
         boundaries = transcript_buffer._detect_sentence_boundaries("Hello world. How are you?")
-        assert len(boundaries) == 1
+        assert len(boundaries) == 2
         assert boundaries[0] == 11  # Position of the period
+        assert boundaries[1] == 24  # Position of the question mark
 
     async def test_timeout_finalization(self, transcript_buffer):
         """Test timeout-based finalization."""

--- a/test/python/unit/voice/test_transcript_manager.py
+++ b/test/python/unit/voice/test_transcript_manager.py
@@ -1,0 +1,378 @@
+"""Tests for the voice transcript management system."""
+
+import pytest
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+from src.python.role_play.voice.transcript_manager import (
+    TranscriptBuffer,
+    TranscriptSegment,
+    BufferedTranscript,
+    SessionTranscriptManager
+)
+from src.python.role_play.common.time_utils import utc_now_isoformat
+
+
+class TestTranscriptBuffer:
+    """Test cases for TranscriptBuffer class."""
+
+    @pytest.fixture
+    def transcript_buffer(self):
+        """Create a test transcript buffer."""
+        return TranscriptBuffer(
+            stability_threshold=0.8,
+            finalization_timeout_ms=1000,  # Short timeout for tests
+            min_utterance_length=2
+        )
+
+    @pytest.fixture
+    def sample_segment(self):
+        """Create a sample transcript segment."""
+        return TranscriptSegment(
+            text="Hello world",
+            stability=0.9,
+            is_final=False,
+            timestamp=utc_now_isoformat(),
+            confidence=0.95,
+            role="user"
+        )
+
+    def test_buffer_initialization(self, transcript_buffer):
+        """Test buffer initializes with correct settings."""
+        assert transcript_buffer.stability_threshold == 0.8
+        assert transcript_buffer.finalization_timeout_ms == 1000
+        assert transcript_buffer.min_utterance_length == 2
+        assert len(transcript_buffer.partial_segments) == 0
+        assert len(transcript_buffer.final_segments) == 0
+
+    async def test_add_partial_segment(self, transcript_buffer, sample_segment):
+        """Test adding partial transcript segments."""
+        display_text, finalized = await transcript_buffer.add_segment(sample_segment)
+        
+        assert display_text == "Hello world"
+        assert finalized is None
+        assert len(transcript_buffer.partial_segments) == 1
+        assert transcript_buffer.partial_segments[0].text == "Hello world"
+
+    async def test_add_final_segment(self, transcript_buffer, sample_segment):
+        """Test adding final transcript segments."""
+        # First add some partials
+        partial1 = TranscriptSegment(
+            text="Hello",
+            stability=0.7,
+            is_final=False,
+            timestamp=utc_now_isoformat(),
+            role="user"
+        )
+        await transcript_buffer.add_segment(partial1)
+        
+        # Then add final segment
+        final_segment = TranscriptSegment(
+            text="Hello world test",
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.95,
+            role="user"
+        )
+        
+        display_text, finalized = await transcript_buffer.add_segment(final_segment)
+        
+        assert display_text == "Hello world test"
+        assert finalized is not None
+        assert isinstance(finalized, BufferedTranscript)
+        assert finalized.text == "Hello world test"
+        assert finalized.role == "user"
+        assert finalized.confidence == 0.95
+        assert len(transcript_buffer.partial_segments) == 0  # Cleared after finalization
+
+    async def test_stability_threshold_filtering(self, transcript_buffer):
+        """Test that low stability segments are filtered."""
+        # Low stability segment should replace previous partials
+        low_stability = TranscriptSegment(
+            text="Uncertain text",
+            stability=0.3,  # Below threshold
+            is_final=False,
+            timestamp=utc_now_isoformat(),
+            role="user"
+        )
+        
+        high_stability = TranscriptSegment(
+            text="Clear text",
+            stability=0.9,  # Above threshold
+            is_final=False,
+            timestamp=utc_now_isoformat(),
+            role="user"
+        )
+        
+        # Add high stability first
+        await transcript_buffer.add_segment(high_stability)
+        assert len(transcript_buffer.partial_segments) == 1
+        
+        # Add low stability - should replace
+        await transcript_buffer.add_segment(low_stability)
+        assert len(transcript_buffer.partial_segments) == 1
+        assert transcript_buffer.partial_segments[0].text == "Uncertain text"
+
+    async def test_min_utterance_length_filtering(self, transcript_buffer):
+        """Test that short utterances are filtered out."""
+        short_final = TranscriptSegment(
+            text="Hi",  # Only 1 word, below min_utterance_length=2
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.95,
+            role="user"
+        )
+        
+        display_text, finalized = await transcript_buffer.add_segment(short_final)
+        
+        assert display_text == "Hi"
+        assert finalized is None  # Should be filtered out
+
+    async def test_sentence_boundary_detection(self, transcript_buffer):
+        """Test sentence boundary detection."""
+        boundaries = transcript_buffer._detect_sentence_boundaries("Hello world. How are you?")
+        assert len(boundaries) == 1
+        assert boundaries[0] == 11  # Position of the period
+
+    async def test_timeout_finalization(self, transcript_buffer):
+        """Test timeout-based finalization."""
+        # Add a partial segment
+        partial = TranscriptSegment(
+            text="Hello world test",
+            stability=0.9,
+            is_final=False,
+            timestamp=utc_now_isoformat(),
+            role="user"
+        )
+        
+        await transcript_buffer.add_segment(partial)
+        
+        # Wait for timeout
+        await asyncio.sleep(1.1)  # Slightly longer than timeout
+        
+        # Check that segment was moved to final
+        assert len(transcript_buffer.partial_segments) == 0
+        assert len(transcript_buffer.final_segments) == 1
+
+    async def test_flush_all_segments(self, transcript_buffer):
+        """Test flushing all pending segments."""
+        # Add some partial segments
+        partials = [
+            TranscriptSegment(
+                text=f"Test segment {i}",
+                stability=0.9,
+                is_final=False,
+                timestamp=utc_now_isoformat(),
+                role="user"
+            )
+            for i in range(3)
+        ]
+        
+        for partial in partials:
+            await transcript_buffer.add_segment(partial)
+        
+        # Flush all
+        flushed = await transcript_buffer.flush()
+        
+        assert len(flushed) == 3
+        assert all(isinstance(t, BufferedTranscript) for t in flushed)
+        assert len(transcript_buffer.partial_segments) == 0
+
+    def test_get_display_text(self, transcript_buffer):
+        """Test display text generation."""
+        # Add some segments manually to test display
+        transcript_buffer.final_segments.append(
+            TranscriptSegment(
+                text="Final text",
+                stability=1.0,
+                is_final=True,
+                timestamp=utc_now_isoformat(),
+                role="user",
+                sequence=1
+            )
+        )
+        
+        transcript_buffer.partial_segments.append(
+            TranscriptSegment(
+                text="partial text",
+                stability=0.8,
+                is_final=False,
+                timestamp=utc_now_isoformat(),
+                role="user",
+                sequence=2
+            )
+        )
+        
+        display_text = transcript_buffer._get_display_text()
+        assert display_text == "Final text partial text"
+
+    def test_clear_buffer(self, transcript_buffer):
+        """Test clearing all buffers."""
+        # Add some segments
+        transcript_buffer.partial_segments.append(Mock())
+        transcript_buffer.final_segments.append(Mock())
+        
+        transcript_buffer.clear()
+        
+        assert len(transcript_buffer.partial_segments) == 0
+        assert len(transcript_buffer.final_segments) == 0
+
+
+class TestSessionTranscriptManager:
+    """Test cases for SessionTranscriptManager class."""
+
+    @pytest.fixture
+    def session_manager(self):
+        """Create a test session transcript manager."""
+        return SessionTranscriptManager(
+            stability_threshold=0.8,
+            finalization_timeout_ms=1000,
+            min_utterance_length=2
+        )
+
+    async def test_add_user_segment(self, session_manager):
+        """Test adding user speech segments."""
+        segment = TranscriptSegment(
+            text="User speaking",
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.9
+        )
+        
+        display_text, finalized = await session_manager.add_user_segment(segment)
+        
+        assert segment.role == "user"
+        assert display_text == "User speaking"
+        assert finalized is not None
+        assert finalized.role == "user"
+
+    async def test_add_assistant_segment(self, session_manager):
+        """Test adding assistant speech segments."""
+        segment = TranscriptSegment(
+            text="Assistant responding",
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.9
+        )
+        
+        display_text, finalized = await session_manager.add_assistant_segment(segment)
+        
+        assert segment.role == "assistant"
+        assert display_text == "Assistant responding"
+        assert finalized is not None
+        assert finalized.role == "assistant"
+
+    async def test_session_statistics(self, session_manager):
+        """Test session statistics tracking."""
+        # Add some segments
+        user_segment = TranscriptSegment(
+            text="User message one",
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.9
+        )
+        
+        assistant_segment = TranscriptSegment(
+            text="Assistant response one",
+            stability=1.0,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.95
+        )
+        
+        await session_manager.add_user_segment(user_segment)
+        await session_manager.add_assistant_segment(assistant_segment)
+        
+        stats = session_manager.get_session_stats()
+        
+        assert stats["total_utterances"] == 2
+        assert stats["total_partials"] == 0
+        assert "started_at" in stats
+        assert "pending_user_segments" in stats
+        assert "pending_assistant_segments" in stats
+
+    async def test_flush_all_transcripts(self, session_manager):
+        """Test flushing transcripts from both user and assistant buffers."""
+        # Add partial segments to both buffers
+        user_partial = TranscriptSegment(
+            text="User partial",
+            stability=0.9,
+            is_final=False,
+            timestamp=utc_now_isoformat()
+        )
+        
+        assistant_partial = TranscriptSegment(
+            text="Assistant partial",
+            stability=0.9,
+            is_final=False,
+            timestamp=utc_now_isoformat()
+        )
+        
+        await session_manager.add_user_segment(user_partial)
+        await session_manager.add_assistant_segment(assistant_partial)
+        
+        # Flush all
+        flushed = await session_manager.flush_all()
+        
+        assert len(flushed) == 2
+        user_transcripts = [t for t in flushed if t.role == "user"]
+        assistant_transcripts = [t for t in flushed if t.role == "assistant"]
+        
+        assert len(user_transcripts) == 1
+        assert len(assistant_transcripts) == 1
+
+
+class TestTranscriptSegment:
+    """Test cases for TranscriptSegment data class."""
+
+    def test_segment_creation(self):
+        """Test creating transcript segments."""
+        segment = TranscriptSegment(
+            text="Test text",
+            stability=0.9,
+            is_final=True,
+            timestamp=utc_now_isoformat(),
+            confidence=0.95,
+            role="user",
+            sequence=1
+        )
+        
+        assert segment.text == "Test text"
+        assert segment.stability == 0.9
+        assert segment.is_final is True
+        assert segment.confidence == 0.95
+        assert segment.role == "user"
+        assert segment.sequence == 1
+
+
+class TestBufferedTranscript:
+    """Test cases for BufferedTranscript data class."""
+
+    def test_transcript_creation(self):
+        """Test creating buffered transcripts."""
+        transcript = BufferedTranscript(
+            text="Final transcript",
+            role="assistant",
+            timestamp=utc_now_isoformat(),
+            duration_ms=2500,
+            confidence=0.92,
+            partial_count=5,
+            voice_metadata={"test": "data"}
+        )
+        
+        assert transcript.text == "Final transcript"
+        assert transcript.role == "assistant"
+        assert transcript.duration_ms == 2500
+        assert transcript.confidence == 0.92
+        assert transcript.partial_count == 5
+        assert transcript.voice_metadata["test"] == "data"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/python/unit/voice/test_voice_handler.py
+++ b/test/python/unit/voice/test_voice_handler.py
@@ -1,0 +1,448 @@
+"""Tests for the voice chat handler."""
+
+import pytest
+import asyncio
+import json
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+from fastapi.testclient import TestClient
+from fastapi import WebSocket
+
+from src.python.role_play.voice.handler import VoiceChatHandler
+from src.python.role_play.voice.models import (
+    VoiceClientRequest,
+    VoiceConfigMessage,
+    VoiceStatusMessage,
+    TranscriptPartialMessage,
+    TranscriptFinalMessage
+)
+from src.python.role_play.common.models import User, UserRole
+
+
+class MockWebSocket:
+    """Mock WebSocket for testing."""
+    
+    def __init__(self):
+        self.accepted = False
+        self.closed = False
+        self.close_code = None
+        self.close_reason = None
+        self.sent_messages = []
+        self.query_params = {}
+        
+    async def accept(self):
+        self.accepted = True
+        
+    async def close(self, code=None, reason=None):
+        self.closed = True
+        self.close_code = code
+        self.close_reason = reason
+        
+    async def send_json(self, data):
+        self.sent_messages.append(data)
+        
+    async def receive_text(self):
+        # Mock receiving client requests
+        return json.dumps({
+            "mime_type": "text/plain",
+            "data": "dGVzdCBtZXNzYWdl",  # "test message" in base64
+            "end_session": False
+        })
+
+
+class TestVoiceChatHandler:
+    """Test cases for VoiceChatHandler."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create a voice chat handler for testing."""
+        return VoiceChatHandler()
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock user."""
+        return User(
+            id="user123",
+            username="testuser",
+            email="test@example.com",
+            role=UserRole.USER,
+            preferred_language="en"
+        )
+
+    @pytest.fixture
+    def mock_websocket(self):
+        """Create a mock WebSocket."""
+        ws = MockWebSocket()
+        ws.query_params = {"token": "valid_token"}
+        return ws
+
+    def test_handler_initialization(self, handler):
+        """Test handler initializes correctly."""
+        assert handler.prefix == "/voice"
+        assert handler.voice_service is not None
+        assert handler.router is not None
+
+    def test_router_endpoints(self, handler):
+        """Test that all expected routes are registered."""
+        router = handler.router
+        routes = [route.path for route in router.routes]
+        
+        # Check that WebSocket and REST endpoints are registered
+        assert "/ws/{session_id}" in routes
+        assert "/session/{session_id}/info" in routes
+        assert "/session/{session_id}/stats" in routes
+        assert "/test" in routes
+
+    @patch('src.python.role_play.voice.handler.get_storage_backend')
+    @patch('src.python.role_play.voice.handler.get_chat_logger')
+    @patch('src.python.role_play.voice.handler.get_adk_session_service')
+    @patch('src.python.role_play.voice.handler.get_resource_loader')
+    async def test_jwt_validation_success(
+        self, 
+        mock_resource_loader,
+        mock_adk_service,
+        mock_chat_logger,
+        mock_storage,
+        handler, 
+        mock_user
+    ):
+        """Test successful JWT token validation."""
+        # Mock dependencies
+        mock_storage_instance = Mock()
+        mock_storage.return_value = mock_storage_instance
+        
+        mock_auth_manager = Mock()
+        mock_auth_manager.verify_token.return_value = Mock(user_id="user123")
+        mock_storage_instance.get_user.return_value = mock_user
+        
+        with patch('src.python.role_play.voice.handler.get_auth_manager', return_value=mock_auth_manager):
+            result = await handler._validate_jwt_token("valid_token")
+            
+            assert result == mock_user
+            mock_auth_manager.verify_token.assert_called_once_with("valid_token")
+
+    async def test_jwt_validation_failure(self, handler):
+        """Test JWT token validation failure."""
+        with patch('src.python.role_play.voice.handler.get_auth_manager') as mock_get_auth:
+            mock_auth_manager = Mock()
+            mock_auth_manager.verify_token.side_effect = Exception("Invalid token")
+            mock_get_auth.return_value = mock_auth_manager
+            
+            result = await handler._validate_jwt_token("invalid_token")
+            
+            assert result is None
+
+    @patch('src.python.role_play.voice.handler.get_storage_backend')
+    @patch('src.python.role_play.voice.handler.get_chat_logger')
+    @patch('src.python.role_play.voice.handler.get_adk_session_service')
+    async def test_session_validation_success(
+        self,
+        mock_adk_service,
+        mock_chat_logger,
+        mock_storage,
+        handler
+    ):
+        """Test successful session validation."""
+        # Mock ADK session
+        mock_adk_session = Mock()
+        mock_adk_session.state = {
+            "character_id": "char123",
+            "scenario_id": "scenario123"
+        }
+        
+        mock_adk_service_instance = Mock()
+        mock_adk_service_instance.get_session.return_value = mock_adk_session
+        mock_adk_service.return_value = mock_adk_service_instance
+        
+        mock_chat_logger_instance = Mock()
+        mock_chat_logger.return_value = mock_chat_logger_instance
+        
+        result = await handler._validate_session(
+            "session123", 
+            "user123", 
+            mock_adk_service_instance, 
+            mock_chat_logger_instance
+        )
+        
+        assert result == mock_adk_session
+
+    @patch('src.python.role_play.voice.handler.get_storage_backend')
+    @patch('src.python.role_play.voice.handler.get_chat_logger')
+    @patch('src.python.role_play.voice.handler.get_adk_session_service')
+    async def test_session_validation_not_found(
+        self,
+        mock_adk_service,
+        mock_chat_logger,
+        mock_storage,
+        handler
+    ):
+        """Test session validation when session not found."""
+        mock_adk_service_instance = Mock()
+        mock_adk_service_instance.get_session.return_value = None
+        mock_adk_service.return_value = mock_adk_service_instance
+        
+        mock_chat_logger_instance = Mock()
+        mock_chat_logger_instance.get_session_end_info.side_effect = Exception("Not found")
+        mock_chat_logger.return_value = mock_chat_logger_instance
+        
+        result = await handler._validate_session(
+            "session123", 
+            "user123", 
+            mock_adk_service_instance, 
+            mock_chat_logger_instance
+        )
+        
+        assert result is None
+
+    async def test_websocket_missing_token(self, handler):
+        """Test WebSocket connection without token."""
+        ws = MockWebSocket()
+        ws.query_params = {}  # No token
+        
+        await handler.handle_voice_session(ws, "session123", None)
+        
+        assert ws.closed
+        assert ws.close_code == 1008
+        assert "Missing token parameter" in str(ws.close_reason)
+
+    @patch('src.python.role_play.voice.handler.VoiceChatHandler._validate_jwt_token')
+    async def test_websocket_invalid_token(self, mock_validate_jwt, handler):
+        """Test WebSocket connection with invalid token."""
+        mock_validate_jwt.return_value = None  # Invalid token
+        
+        ws = MockWebSocket()
+        ws.query_params = {"token": "invalid_token"}
+        
+        await handler.handle_voice_session(ws, "session123", "invalid_token")
+        
+        assert ws.closed
+        assert ws.close_code == 1008
+        assert "Invalid authentication token" in str(ws.close_reason)
+
+    def test_voice_client_request_validation(self):
+        """Test VoiceClientRequest model validation."""
+        # Valid request
+        request = VoiceClientRequest(
+            mime_type="audio/pcm",
+            data="dGVzdCBhdWRpbw==",  # base64 encoded
+            end_session=False
+        )
+        
+        assert request.mime_type == "audio/pcm"
+        assert request.data == "dGVzdCBhdWRpbw=="
+        assert request.end_session is False
+        
+        # Test data decoding
+        decoded = request.decode_data()
+        assert isinstance(decoded, bytes)
+
+    def test_voice_client_request_text_decoding(self):
+        """Test VoiceClientRequest text data decoding."""
+        request = VoiceClientRequest(
+            mime_type="text/plain",
+            data="dGVzdCB0ZXh0",  # "test text" in base64
+            end_session=False
+        )
+        
+        decoded = request.decode_data()
+        assert decoded == "test text"
+        assert isinstance(decoded, str)
+
+    def test_voice_config_message(self):
+        """Test VoiceConfigMessage creation."""
+        config = VoiceConfigMessage(
+            audio_format="pcm",
+            sample_rate=16000,
+            channels=1,
+            bit_depth=16,
+            language="en",
+            voice_name="Aoede"
+        )
+        
+        assert config.type == "config"
+        assert config.audio_format == "pcm"
+        assert config.sample_rate == 16000
+        assert config.language == "en"
+
+    def test_voice_status_message(self):
+        """Test VoiceStatusMessage creation."""
+        status = VoiceStatusMessage(
+            status="connected",
+            message="Voice session connected"
+        )
+        
+        assert status.type == "status"
+        assert status.status == "connected"
+        assert status.message == "Voice session connected"
+
+    def test_transcript_partial_message(self):
+        """Test TranscriptPartialMessage creation."""
+        partial = TranscriptPartialMessage(
+            text="Hello world",
+            role="user",
+            stability=0.85,
+            timestamp="2025-01-14T10:30:00Z"
+        )
+        
+        assert partial.type == "transcript_partial"
+        assert partial.text == "Hello world"
+        assert partial.role == "user"
+        assert partial.stability == 0.85
+
+    def test_transcript_final_message(self):
+        """Test TranscriptFinalMessage creation."""
+        final = TranscriptFinalMessage(
+            text="Hello world final",
+            role="assistant",
+            duration_ms=2500,
+            confidence=0.92,
+            metadata={"test": "data"},
+            timestamp="2025-01-14T10:30:00Z"
+        )
+        
+        assert final.type == "transcript_final"
+        assert final.text == "Hello world final"
+        assert final.role == "assistant"
+        assert final.duration_ms == 2500
+        assert final.confidence == 0.92
+        assert final.metadata["test"] == "data"
+
+    @patch('src.python.role_play.voice.handler.VoiceChatHandler._validate_jwt_token')
+    @patch('src.python.role_play.voice.handler.VoiceChatHandler._validate_session')
+    @patch('src.python.role_play.voice.handler.get_storage_backend')
+    @patch('src.python.role_play.voice.handler.get_chat_logger')
+    @patch('src.python.role_play.voice.handler.get_adk_session_service')
+    @patch('src.python.role_play.voice.handler.get_resource_loader')
+    async def test_websocket_connection_flow(
+        self,
+        mock_resource_loader,
+        mock_adk_service,
+        mock_chat_logger,
+        mock_storage,
+        mock_validate_session,
+        mock_validate_jwt,
+        handler,
+        mock_user
+    ):
+        """Test the complete WebSocket connection flow."""
+        # Setup mocks
+        mock_validate_jwt.return_value = mock_user
+        
+        mock_adk_session = Mock()
+        mock_adk_session.state = {
+            "character_id": "char123",
+            "scenario_id": "scenario123",
+            "script_data": None
+        }
+        mock_validate_session.return_value = mock_adk_session
+        
+        # Mock voice service
+        mock_voice_session = Mock()
+        mock_voice_session.active = False  # Will exit streaming loop immediately
+        mock_voice_session.cleanup.return_value = {"stats": "test"}
+        
+        with patch.object(handler.voice_service, 'create_voice_session', return_value=mock_voice_session):
+            ws = MockWebSocket()
+            ws.query_params = {"token": "valid_token"}
+            
+            # This should complete without errors
+            await handler.handle_voice_session(ws, "session123", "valid_token")
+            
+            # Check that WebSocket was accepted and messages were sent
+            assert ws.accepted
+            assert len(ws.sent_messages) >= 2  # At least status and config messages
+            
+            # Check message types
+            message_types = [msg.get("type") for msg in ws.sent_messages]
+            assert "status" in message_types
+
+    @pytest.mark.asyncio
+    async def test_receive_from_client_text_message(self, handler):
+        """Test receiving text message from client."""
+        mock_voice_session = Mock()
+        mock_voice_session.active = True
+        mock_voice_session.send_text = AsyncMock()
+        mock_voice_session.end_session = AsyncMock()
+        
+        # Mock WebSocket that returns a text message then ends
+        ws = Mock()
+        text_request = {
+            "mime_type": "text/plain",
+            "data": "dGVzdCBtZXNzYWdl",  # "test message" in base64
+            "end_session": False
+        }
+        end_request = {
+            "mime_type": "text/plain",
+            "data": "",
+            "end_session": True
+        }
+        
+        ws.receive_text.side_effect = [
+            json.dumps(text_request),
+            json.dumps(end_request)
+        ]
+        
+        await handler._receive_from_client(ws, mock_voice_session)
+        
+        # Verify text was sent to voice session
+        mock_voice_session.send_text.assert_called_once_with("test message")
+        mock_voice_session.end_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_receive_from_client_audio_message(self, handler):
+        """Test receiving audio message from client."""
+        mock_voice_session = Mock()
+        mock_voice_session.active = True
+        mock_voice_session.send_audio = AsyncMock()
+        mock_voice_session.end_session = AsyncMock()
+        
+        # Mock WebSocket that returns an audio message then ends
+        ws = Mock()
+        audio_request = {
+            "mime_type": "audio/pcm",
+            "data": "dGVzdCBhdWRpbw==",  # "test audio" in base64
+            "end_session": False
+        }
+        end_request = {
+            "mime_type": "audio/pcm",
+            "data": "",
+            "end_session": True
+        }
+        
+        ws.receive_text.side_effect = [
+            json.dumps(audio_request),
+            json.dumps(end_request)
+        ]
+        
+        await handler._receive_from_client(ws, mock_voice_session)
+        
+        # Verify audio was sent to voice session
+        mock_voice_session.send_audio.assert_called_once()
+        call_args = mock_voice_session.send_audio.call_args
+        assert call_args[0][1] == "audio/pcm"  # mime_type argument
+        mock_voice_session.end_session.assert_called_once()
+
+
+class TestVoiceHandlerIntegration:
+    """Integration tests for voice handler."""
+
+    @pytest.fixture
+    def app_with_voice_handler(self):
+        """Create FastAPI app with voice handler for testing."""
+        from fastapi import FastAPI
+        app = FastAPI()
+        handler = VoiceChatHandler()
+        app.include_router(handler.router, prefix=handler.prefix)
+        return app
+
+    def test_voice_handler_routes_registered(self, app_with_voice_handler):
+        """Test that voice handler routes are properly registered."""
+        client = TestClient(app_with_voice_handler)
+        
+        # Test the simple endpoint
+        response = client.get("/voice/test")
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR improves the voice WebSocket implementation to better align with best practices for low-latency, bi-directional audio streaming applications.

What’s included
- Pre-accept auth: validate JWT before WebSocket upgrade (policy close 1008 on failure).
- Backpressure: bounded producer/consumer queue; coalesce/drop transcript partials under pressure to protect latency.
- Heartbeat: periodic ping (20s) to detect stale connections and aid intermediaries.
- Input limits: reject oversized audio chunks (>256KB) with 1009; basic rate protection.
- Sequencing: add `sequence` to outgoing audio chunks for client-side ordering.
- Cleanup: graceful shutdown of live event generator and ADK runner.

Compatibility notes
- Server now accepts binary audio frames (`receive()` path); JSON+base64 text frames remain supported.
- Auth token still accepted via query for backward compatibility, but pre-accept validation occurs. Consider migrating to header/subprotocol in a follow-up.

Files
- src/python/role_play/voice/handler.py
- src/python/role_play/voice/adk_voice_service.py

Risk & verification
- Local: run `python src/python/run_server.py` and connect with the existing UI; voice flow should remain functional.
- Make: `make test-chat` covers chat; voice path remains integration-tested manually.

Follow-ups (optional)
- Switch outgoing audio to binary frames to remove base64 overhead.
- Add client heartbeat handling and idle timeout enforcement.
- Migrate token to header or `Sec-WebSocket-Protocol`.
