### PR TITLE
feat: buffer and log voice transcripts

### DIFF
--- a/src/python/role_play/voice/__init__.py
+++ b/src/python/role_play/voice/__init__.py
@@ -1,0 +1,9 @@
+"""Voice chat support for the Role Play System."""
+
+from .adk_voice_service import ADKVoiceService
+from .handler import VoiceChatHandler
+
+__all__ = [
+    "ADKVoiceService",
+    "VoiceChatHandler",
+]

--- a/src/python/role_play/voice/adk_voice_service.py
+++ b/src/python/role_play/voice/adk_voice_service.py
@@ -1,0 +1,78 @@
+"""ADK voice service for managing live streaming sessions."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, Tuple, Optional
+
+from google.adk.runners import InMemoryRunner
+from google.adk.agents import LiveRequestQueue
+from google.adk.agents.run_config import RunConfig
+from google.genai.types import AudioTranscriptionConfig
+
+from ..dev_agents.roleplay_agent.agent import get_production_agent
+
+
+class ADKVoiceService:
+    """Service that creates and manages ADK live sessions for voice chat."""
+
+    async def create_voice_session(
+        self,
+        session_id: str,
+        user_id: str,
+        character_id: str,
+        scenario_id: str,
+        language: str,
+        script_data: Optional[dict] = None,
+    ) -> Tuple[AsyncGenerator, LiveRequestQueue]:
+        """Create and start an ADK live session.
+
+        Args:
+            session_id: Identifier for the conversation session.
+            user_id: Identifier of the connected user.
+            character_id: Character identifier for the role play.
+            scenario_id: Scenario identifier for the role play.
+            language: Language code for the interaction.
+            script_data: Optional script information if the session is scripted.
+
+        Returns:
+            Tuple containing an async generator of live events and the request queue
+            used to send messages to the agent.
+        """
+        agent = await get_production_agent(
+            character_id=character_id,
+            scenario_id=scenario_id,
+            language=language,
+            scripted=bool(script_data),
+        )
+
+        runner = InMemoryRunner(app_name="roleplay_voice", agent=agent)
+
+        initial_state = {
+            "character_id": character_id,
+            "scenario_id": scenario_id,
+            "script_data": script_data,
+            "language": language,
+        }
+
+        session = await runner.session_service.create_session(
+            app_name="roleplay_voice",
+            user_id=user_id,
+            session_id=session_id,
+            state=initial_state,
+        )
+
+        run_config = RunConfig(
+            response_modalities=["AUDIO"],
+            output_audio_transcription=AudioTranscriptionConfig(),
+            input_audio_transcription=AudioTranscriptionConfig(),
+        )
+
+        live_request_queue = LiveRequestQueue()
+
+        live_events = runner.run_live(
+            session=session,
+            live_request_queue=live_request_queue,
+            run_config=run_config,
+        )
+
+        return live_events, live_request_queue

--- a/src/python/role_play/voice/handler.py
+++ b/src/python/role_play/voice/handler.py
@@ -1,0 +1,193 @@
+"""WebSocket handler for real-time voice conversations."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from typing import Any, AsyncGenerator, Dict
+
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect
+from google.adk.agents import LiveRequestQueue
+from google.genai.types import Blob, Content, Part
+
+from .adk_voice_service import ADKVoiceService
+from ..chat.chat_logger import ChatLogger
+from ..server.dependencies import (
+    get_adk_session_service,
+    get_auth_manager,
+    get_chat_logger,
+    get_storage_backend,
+)
+from ..common.exceptions import AuthenticationError, TokenExpiredError
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceChatHandler:
+    """Handler managing a bidirectional voice chat session over WebSocket."""
+
+    def __init__(self, chat_logger: ChatLogger | None = None) -> None:
+        self.voice_service = ADKVoiceService()
+        # Allow dependency injection for easier testing
+        self.chat_logger = chat_logger or get_chat_logger(get_storage_backend())
+        # Track message counts per session for logging
+        self._message_counters: Dict[str, int] = {}
+
+    async def handle_voice_session(
+        self, websocket: WebSocket, session_id: str, token: str
+    ) -> None:
+        """Main entry point for handling a voice WebSocket session."""
+        user = await self._validate_jwt_token(token)
+        adk_session = await self._get_adk_session(session_id, user.id)
+
+        live_events, live_request_queue = await self.voice_service.create_voice_session(
+            session_id=session_id,
+            user_id=user.id,
+            character_id=adk_session.state["character_id"],
+            scenario_id=adk_session.state["scenario_id"],
+            script_data=adk_session.state.get("script_data"),
+            language=adk_session.state.get("language", "en"),
+        )
+
+        # Initialize message counter for this session
+        self._message_counters[session_id] = adk_session.state.get("message_count", 0)
+
+        client_to_agent_task = asyncio.create_task(
+            self._handle_client_to_agent(websocket, live_request_queue)
+        )
+        agent_to_client_task = asyncio.create_task(
+            self._handle_agent_to_client(
+                websocket, live_events, session_id, user.id
+            )
+        )
+
+        try:
+            done, pending = await asyncio.wait(
+                [client_to_agent_task, agent_to_client_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+        finally:
+            live_request_queue.close()
+            self._message_counters.pop(session_id, None)
+
+    async def _handle_client_to_agent(
+        self, websocket: WebSocket, queue: LiveRequestQueue
+    ) -> None:
+        """Stream audio/text from the client to the agent."""
+        try:
+            while True:
+                data = await websocket.receive_json()
+                if data.get("type") == "audio":
+                    audio_bytes = base64.b64decode(data["data"])
+                    await queue.send_realtime(Blob(mime_type="audio/pcm", data=audio_bytes))
+                elif data.get("type") == "text":
+                    await queue.send_content(Content(parts=[Part(text=data["text"])]))
+        except WebSocketDisconnect:
+            pass
+
+    async def _handle_agent_to_client(
+        self,
+        websocket: WebSocket,
+        live_events: AsyncGenerator,
+        session_id: str,
+        user_id: str,
+    ) -> None:
+        """
+        Stream responses from the agent to the client while buffering transcript
+        text for logging when a turn completes.
+        """
+        transcript_buffer: list[str] = []
+
+        try:
+            async for event in live_events:
+                if getattr(event, "input_transcription", None):
+                    await websocket.send_json(
+                        {
+                            "type": "transcript",
+                            "role": "user",
+                            "text": event.input_transcription.text,
+                        }
+                    )
+                if getattr(event, "output_transcription", None):
+                    await websocket.send_json(
+                        {
+                            "type": "transcript",
+                            "role": "assistant",
+                            "text": event.output_transcription.text,
+                        }
+                    )
+
+                part = getattr(event, "content", None)
+                part = part and part.parts and part.parts[0]
+
+                if part:
+                    if getattr(part, "inline_data", None) and part.inline_data.mime_type.startswith(
+                        "audio"
+                    ):
+                        audio_data = base64.b64encode(part.inline_data.data).decode("utf-8")
+                        await websocket.send_json({"type": "audio", "data": audio_data})
+                    elif getattr(part, "text", None) and getattr(event, "partial", False):
+                        transcript_buffer.append(part.text)
+                        await websocket.send_json(
+                            {"type": "text", "data": part.text, "partial": True}
+                        )
+
+                if getattr(event, "turn_complete", False) or getattr(
+                    event, "interrupted", False
+                ):
+                    if transcript_buffer:
+                        full_transcript = "".join(transcript_buffer)
+                        message_num = self._message_counters.get(session_id, 0) + 1
+                        self._message_counters[session_id] = message_num
+                        try:
+                            await self.chat_logger.log_message(
+                                user_id=user_id,
+                                session_id=session_id,
+                                role="assistant",
+                                content=full_transcript,
+                                message_number=message_num,
+                            )
+                        except Exception as log_err:  # pragma: no cover - logging failure shouldn't crash session
+                            logger.error(
+                                "Failed to log transcript for session %s: %s",
+                                session_id,
+                                log_err,
+                            )
+                        transcript_buffer.clear()
+
+                    await websocket.send_json(
+                        {
+                            "type": "turn_status",
+                            "turn_complete": getattr(event, "turn_complete", False),
+                            "interrupted": getattr(event, "interrupted", False),
+                        }
+                    )
+        except Exception as e:  # pragma: no cover - best effort logging
+            logger.error("Error in agent->client stream for session %s: %s", session_id, e)
+
+    async def _validate_jwt_token(self, token: str) -> Any:
+        """Validate JWT token and return the associated user."""
+        auth_manager = get_auth_manager(get_storage_backend())
+        try:
+            token_data = auth_manager.verify_token(token)
+            user = await auth_manager.storage.get_user(token_data.user_id)
+            if user is None:
+                raise HTTPException(status_code=401, detail="User not found")
+            return user
+        except TokenExpiredError as exc:
+            raise HTTPException(status_code=401, detail="Token expired") from exc
+        except AuthenticationError as exc:
+            raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+    async def _get_adk_session(self, session_id: str, user_id: str) -> Any:
+        """Retrieve an existing ADK session for the user."""
+        session_service = get_adk_session_service()
+        session = await session_service.get_session(
+            app_name="roleplay_voice", user_id=user_id, session_id=session_id
+        )
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return session

--- a/test/python/unit/voice/test_adk_voice_service.py
+++ b/test/python/unit/voice/test_adk_voice_service.py
@@ -1,0 +1,55 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from role_play.voice.adk_voice_service import ADKVoiceService
+
+
+@pytest.mark.asyncio
+async def test_create_voice_session_sets_up_runner():
+    service = ADKVoiceService()
+
+    with (
+        patch("role_play.voice.adk_voice_service.get_production_agent", AsyncMock(return_value="agent")) as get_agent,
+        patch("role_play.voice.adk_voice_service.InMemoryRunner") as RunnerMock,
+        patch("role_play.voice.adk_voice_service.RunConfig") as RunConfigMock,
+        patch("role_play.voice.adk_voice_service.LiveRequestQueue") as QueueMock,
+        patch("role_play.voice.adk_voice_service.AudioTranscriptionConfig") as ATConfigMock,
+    ):
+        session_service = AsyncMock()
+        session_service.create_session.return_value = SimpleNamespace()
+        runner_instance = Mock()
+        runner_instance.session_service = session_service
+        runner_instance.run_live.return_value = "events"
+        RunnerMock.return_value = runner_instance
+
+        queue_instance = Mock()
+        QueueMock.return_value = queue_instance
+        run_config_instance = Mock()
+        RunConfigMock.return_value = run_config_instance
+
+        events, queue = await service.create_voice_session(
+            session_id="sess", user_id="user", character_id="char", scenario_id="scen", language="en"
+        )
+
+        assert events == "events"
+        assert queue is queue_instance
+        get_agent.assert_awaited_with(
+            character_id="char", scenario_id="scen", language="en", scripted=False
+        )
+        RunnerMock.assert_called_with(app_name="roleplay_voice", agent="agent")
+        session_service.create_session.assert_awaited_with(
+            app_name="roleplay_voice", user_id="user", session_id="sess", state={
+                "character_id": "char",
+                "scenario_id": "scen",
+                "script_data": None,
+                "language": "en",
+            }
+        )
+        runner_instance.run_live.assert_called_with(
+            session=session_service.create_session.return_value,
+            live_request_queue=queue_instance,
+            run_config=run_config_instance,
+        )

--- a/test/python/unit/voice/test_voice_chat_handler.py
+++ b/test/python/unit/voice/test_voice_chat_handler.py
@@ -1,0 +1,177 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import base64
+import pytest
+from fastapi import WebSocketDisconnect
+
+from role_play.voice.handler import VoiceChatHandler
+
+
+@pytest.mark.asyncio
+async def test_handle_client_to_agent_audio_and_text(monkeypatch):
+    handler = VoiceChatHandler(chat_logger=AsyncMock())
+
+    # Patch Blob, Content, Part to simple test classes
+    class DummyBlob:
+        def __init__(self, mime_type, data):
+            self.mime_type = mime_type
+            self.data = data
+
+    class DummyPart:
+        def __init__(self, text=None):
+            self.text = text
+
+    class DummyContent:
+        def __init__(self, parts):
+            self.parts = parts
+
+    monkeypatch.setattr("role_play.voice.handler.Blob", DummyBlob)
+    monkeypatch.setattr("role_play.voice.handler.Content", DummyContent)
+    monkeypatch.setattr("role_play.voice.handler.Part", DummyPart)
+
+    audio_bytes = b"abc"
+    ws = AsyncMock()
+    ws.receive_json.side_effect = [
+        {"type": "audio", "data": base64.b64encode(audio_bytes).decode()},
+        {"type": "text", "text": "hi"},
+        WebSocketDisconnect(),
+    ]
+
+    queue = AsyncMock()
+    await handler._handle_client_to_agent(ws, queue)
+
+    queue.send_realtime.assert_awaited()
+    blob_arg = queue.send_realtime.await_args.args[0]
+    assert isinstance(blob_arg, DummyBlob)
+    assert blob_arg.data == audio_bytes
+
+    queue.send_content.assert_awaited()
+    content_arg = queue.send_content.await_args.args[0]
+    assert isinstance(content_arg, DummyContent)
+    assert content_arg.parts[0].text == "hi"
+
+
+@pytest.mark.asyncio
+async def test_handle_agent_to_client_sends_messages(monkeypatch):
+    handler = VoiceChatHandler(chat_logger=AsyncMock())
+    ws = AsyncMock()
+
+    class DummyInline:
+        def __init__(self, data):
+            self.data = data
+            self.mime_type = "audio/pcm"
+
+    audio_event = SimpleNamespace(
+        turn_complete=True,
+        interrupted=False,
+        input_transcription=SimpleNamespace(text="user words"),
+        output_transcription=SimpleNamespace(text="assistant words"),
+        content=SimpleNamespace(parts=[SimpleNamespace(inline_data=DummyInline(b"data"), text=None)]),
+        partial=False,
+    )
+
+    text_event = SimpleNamespace(
+        turn_complete=False,
+        interrupted=False,
+        input_transcription=None,
+        output_transcription=None,
+        content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None, text="partial")]),
+        partial=True,
+    )
+
+    async def event_gen():
+        yield audio_event
+        yield text_event
+
+    await handler._handle_agent_to_client(ws, event_gen(), "sess", "user")
+
+    calls = [call.args[0] for call in ws.send_json.call_args_list]
+    assert {"type": "turn_status", "turn_complete": True, "interrupted": False} in calls
+    assert {"type": "transcript", "role": "user", "text": "user words"} in calls
+    assert {"type": "transcript", "role": "assistant", "text": "assistant words"} in calls
+    audio_base64 = base64.b64encode(b"data").decode("utf-8")
+    assert {"type": "audio", "data": audio_base64} in calls
+    assert {"type": "text", "data": "partial", "partial": True} in calls
+
+
+@pytest.mark.asyncio
+async def test_handle_voice_session_runs_and_cleans(monkeypatch):
+    handler = VoiceChatHandler(chat_logger=AsyncMock())
+    ws = AsyncMock()
+    queue = Mock()
+
+    async def dummy_events():
+        if False:
+            yield None
+
+    monkeypatch.setattr(handler, "_validate_jwt_token", AsyncMock(return_value=SimpleNamespace(id="u")))
+    monkeypatch.setattr(
+        handler,
+        "_get_adk_session",
+        AsyncMock(return_value=SimpleNamespace(state={"character_id": "c", "scenario_id": "s"})),
+    )
+    handler.voice_service.create_voice_session = AsyncMock(return_value=(dummy_events(), queue))
+    monkeypatch.setattr(handler, "_handle_client_to_agent", AsyncMock())
+    monkeypatch.setattr(handler, "_handle_agent_to_client", AsyncMock())
+
+    await handler.handle_voice_session(ws, "sess", "token")
+
+    handler._handle_client_to_agent.assert_awaited()
+    handler._handle_agent_to_client.assert_awaited()
+    assert queue.close.called
+
+
+@pytest.mark.asyncio
+async def test_transcript_buffer_logged(monkeypatch):
+    chat_logger = AsyncMock()
+    handler = VoiceChatHandler(chat_logger=chat_logger)
+    ws = AsyncMock()
+
+    # Two partial text events followed by turn completion
+    part_event1 = SimpleNamespace(
+        turn_complete=False,
+        interrupted=False,
+        input_transcription=None,
+        output_transcription=None,
+        content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None, text="Hello ")]),
+        partial=True,
+    )
+    part_event2 = SimpleNamespace(
+        turn_complete=False,
+        interrupted=False,
+        input_transcription=None,
+        output_transcription=None,
+        content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None, text="world")]),
+        partial=True,
+    )
+    turn_event = SimpleNamespace(
+        turn_complete=True,
+        interrupted=False,
+        input_transcription=None,
+        output_transcription=None,
+        content=None,
+        partial=False,
+    )
+
+    async def events():
+        yield part_event1
+        yield part_event2
+        yield turn_event
+
+    await handler._handle_agent_to_client(ws, events(), "sess", "user")
+
+    # Ensure full transcript logged once
+    chat_logger.log_message.assert_awaited_once_with(
+        user_id="user",
+        session_id="sess",
+        role="assistant",
+        content="Hello world",
+        message_number=1,
+    )
+
+    # Partial text chunks forwarded to client
+    sends = [c.args[0] for c in ws.send_json.call_args_list]
+    assert {"type": "text", "data": "Hello ", "partial": True} in sends
+    assert {"type": "text", "data": "world", "partial": True} in sends
+    assert {"type": "turn_status", "turn_complete": True, "interrupted": False} in sends


### PR DESCRIPTION
## Summary
- buffer assistant text chunks per turn and log the full transcript via ChatLogger
- expose ChatLogger in `VoiceChatHandler` and track per-session message numbers
- add tests covering transcript buffering and logging behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d0556181c83298de83a0b39bd9c04