### PR TITLE
feat(packaging): Add Python package publishing infrastructure

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,32 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on tags like v0.1.0, v1.2.3, etc.
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python package to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies and build package
+      run: |
+        cd src/python
+        ./build.sh
+      
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: src/python/role_play/dist/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: Publish Python Package to GCP Artifact Registry
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-publish:
-    name: Build and publish Python package to PyPI
+    name: Build and publish Python package to GCP Artifact Registry
     runs-on: ubuntu-latest
 
     steps:
@@ -23,10 +23,14 @@ jobs:
       run: |
         cd src/python
         ./build.sh
-      
-    - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v2'
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: src/python/role_play/dist/
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Publish to Artifact Registry
+      run: |
+        pip install twine
+        twine upload --repository-url https://${{ secrets.GCP_REGION }}-python.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_ARTIFACT_REGISTRY_REPO }}/ dist/*
+      working-directory: src/python/role_play

--- a/Makefile
+++ b/Makefile
@@ -381,18 +381,10 @@ dev-setup: load-env-mk
 	@echo "Or use PyCharm to run src/python/run_server.py"
 
 # --- Release Management ---
-.PHONY: tag-git-release
-tag-git-release: # Expects NEW_GIT_TAG to be set, e.g., make tag-git-release NEW_GIT_TAG=v1.0.0
-ifndef NEW_GIT_TAG
-	$(error NEW_GIT_TAG is not set. Usage: make tag-git-release NEW_GIT_TAG=vX.Y.Z)
-endif
-	@echo "Creating Git tag: $(NEW_GIT_TAG)"
-	@read -p "Enter commit message for tag $(NEW_GIT_TAG) (Press Enter for default: 'Release $(NEW_GIT_TAG)'): " msg; \
-	COMMIT_MSG=$${msg:-Release $(NEW_GIT_TAG)}; \
-	git tag -a "$(NEW_GIT_TAG)" -m "$$COMMIT_MSG"
-	@echo "Pushing Git tag $(NEW_GIT_TAG) to origin..."
-	@git push origin "$(NEW_GIT_TAG)"
-	@echo "Git tag $(NEW_GIT_TAG) created and pushed."
+.PHONY: release
+release:
+	@echo "To create a new release, create and push a new git tag."
+	@echo "Example: git tag v0.1.0 && git push origin v0.1.0"
 
 # --- GCP Setup ---
 .PHONY: setup-gcp-infra

--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ GET  /api/eval/session/{id}/all_reports    # Historical evaluations
 
 ## Deployment Guide
 
+---
+
+## 📦 Packaging and Publishing
+
+This repository is set up to be distributed as a Python package.
+
+### Manual Build
+
+To build the package locally:
+
+1.  Navigate to the `src/python` directory.
+2.  Ensure you have the latest build tools: `pip install --upgrade setuptools wheel`.
+3.  Run the build script: `./build.sh`.
+
+The distributable files (`.tar.gz` and `.whl`) will be located in `src/python/role_play/dist/`.
+
+### Automated Publishing
+
+The package is automatically published to PyPI via a GitHub Action. To publish a new version:
+
+1.  Ensure the `version` in `src/python/role_play/setup.py` has been updated.
+2.  Create and push a new git tag that starts with `v` (e.g., `git tag v0.1.0` and `git push origin v0.1.0`).
+
+The `publish-package.yml` workflow will handle the rest.
+
+
 ### **Cloud Deployment (Production)**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -215,33 +215,9 @@ GET  /api/eval/session/{id}/all_reports    # Historical evaluations
 
 ---
 
-## Deployment Guide
-
 ---
 
-## 📦 Packaging and Publishing
-
-This repository is set up to be distributed as a Python package.
-
-### Manual Build
-
-To build the package locally:
-
-1.  Navigate to the `src/python` directory.
-2.  Ensure you have the latest build tools: `pip install --upgrade setuptools wheel`.
-3.  Run the build script: `./build.sh`.
-
-The distributable files (`.tar.gz` and `.whl`) will be located in `src/python/role_play/dist/`.
-
-### Automated Publishing
-
-The package is automatically published to PyPI via a GitHub Action. To publish a new version:
-
-1.  Ensure the `version` in `src/python/role_play/setup.py` has been updated.
-2.  Create and push a new git tag that starts with `v` (e.g., `git tag v0.1.0` and `git push origin v0.1.0`).
-
-The `publish-package.yml` workflow will handle the rest.
-
+## Deploying the Application
 
 ### **Cloud Deployment (Production)**
 
@@ -272,3 +248,35 @@ ENV=prod GCS_BUCKET=prod-bucket JWT_SECRET_KEY=secure-key python run_server.py
 ```
 
 ** See [DEPLOYMENT.md](./DEPLOYMENT.md) for detailed instructions**
+
+--- 
+
+## 📦 Publishing the Library
+
+This repository is set up to be distributed as a Python package.
+
+### Manual Build
+
+To build the package locally:
+
+1.  Navigate to the `src/python` directory.
+2.  Ensure you have the latest build tools: `pip install --upgrade setuptools wheel`.
+3.  Run the build script: `./build.sh`.
+
+The distributable files (`.tar.gz` and `.whl`) will be located in `src/python/role_play/dist/`.
+
+### Automated Publishing
+
+The package is automatically published to a private GCP Artifact Registry via a GitHub Action. To publish a new version:
+
+1.  Ensure the `version` in `src/python/role_play/setup.py` has been updated.
+2.  Create and push a new git tag that starts with `v` (e.g., `git tag v0.1.0` and `git push origin v0.1.0`).
+
+The `publish-package.yml` workflow will handle the rest.
+
+**Note**: Before this action can work, you must create a GCP service account with permissions to write to Artifact Registry and add the following secrets to your GitHub repository:
+* `GCP_PROJECT_ID`: Your GCP project ID.
+* `GCP_SA_KEY`: The JSON key for your service account.
+* `GCP_REGION`: The GCP region for your Artifact Registry (e.g., `us-central1`).
+* `GCP_ARTIFACT_REGISTRY_REPO`: The name of your Artifact Registry repository for Python packages.
+

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Navigate to the package directory
+cd "$(dirname "$0")/role_play"
+
+# Remove old build artifacts
+echo "Cleaning old build artifacts..."
+rm -rf dist build *.egg-info
+
+# Install necessary build tools
+echo "Installing build dependencies..."
+python3 -m pip install --upgrade setuptools wheel
+
+# Build the source and wheel distributions
+echo "Building the package..."
+python3 setup.py sdist bdist_wheel
+
+echo "Build complete. Artifacts are in dist/"


### PR DESCRIPTION
## Summary
• Add GitHub Actions workflow for automated Python package publishing to GCP Artifact Registry
• Create build automation script with proper cleanup and dependency management  
• Update Makefile to simplify release process with clear git tag instructions
• Enhance README with comprehensive packaging and publishing documentation

## Changes Made
• **GitHub Actions**: New `publish-package.yml` workflow triggered by version tags (v*)
• **Build Script**: Automated `build.sh` script with cleanup, dependency installation, and artifact generation
• **Release Process**: Simplified Makefile `release` target with clear git tagging guidance
• **Documentation**: Added detailed packaging section to README with manual build and automated publishing instructions

## Test Plan
- [x] Verify build script executes successfully in `src/python` directory
- [x] Confirm GitHub Actions workflow syntax is valid
- [x] Test Makefile release target displays correct instructions
- [ ] Validate end-to-end publishing flow with test tag (requires GCP secrets configuration)
- [ ] Confirm package artifacts are correctly generated in `dist/` directory

🤖 Generated with [Claude Code](https://claude.ai/code)